### PR TITLE
feat(policy): extension-supplied condition fields (seam S2)

### DIFF
--- a/docs/enterprise-seams-design.md
+++ b/docs/enterprise-seams-design.md
@@ -1,6 +1,6 @@
 # Enterprise seams for open `xaidr` — design against `864243e`
 
-**Status:** S7 built (PR 1 of the sequencing below); S1 + S5 + S6 built (PR 2). S2, S3, S4, S8–S13 still design. Base: `delphisecurity/xaidr` main at `864243e` (release 1.11.0); the seam line numbers in §2 are on that commit and have since shifted — read them as "which function", not "which line". PR #3 (ASI/LPCI rules) shifts `local.py` by +34 lines and touches no seam site.
+**Status:** S7 built (PR 1 of the sequencing below); S1 + S5 + S6 built (PR 2); S2 built (PR 3). S3, S4, S8–S13 still design. Base: `delphisecurity/xaidr` main at `864243e` (release 1.11.0); the seam line numbers in §2 are on that commit and have since shifted — read them as "which function", not "which line". PR #3 (ASI/LPCI rules) shifts `local.py` by +34 lines and touches no seam site.
 **Companion:** `docs/enterprise-overlay-spec.md` (the bucket classification, currently sitting in `~/delphi-sentinel/docs/`, to be moved to the SDK repo). This document replaces its §5 hook table.
 **Goal:** paid = pinned open `xaidr` + an enterprise package. Every behaviour paid has today that open lacks must plug into open through a public, tested, validated-at-construction seam, so that the next open release cannot silently break the enterprise package and the next enterprise feature cannot fork a shared file.
 
@@ -54,13 +54,23 @@ Validate every item is a `SensorExtension` (raise otherwise), store the tuple, c
 
 Inherits fresh code: `self._breaker_faults` (`:372-375`) is in the same function. Insert after the breaker wiring at `:386` so extensions see a fully built sensor.
 
-### S2 · policy conditions — `authz/policy.py:79` and `:161` (was H2 + H10)
+### S2 · policy conditions — `authz/policy.py` + `local_policy.py` (was H2 + H10), BUILT
 
 The spec's two sites are one seam. Today `_CONDITION_FIELDS` is a module-level frozenset consulted inside `parse_action_policy`, `trust_below` is rejected at `:161` in both placements, and `_reject_unknown_keys` (`:82`, applied `:175/:177`) would reject it a second time with a misleading did-you-mean.
 
 Design: `parse_action_policy(doc, *, extra_conditions: Mapping[str, ConditionEvaluator] = {})`. `load_policy` gains the same kwarg and forwards it. `DelphiSensor.__init__` collects `policy_conditions()` from every extension, merges (duplicate key across extensions → construction error), and passes the merged map. Inside the parser, the valid-key set for the unknown-key validator is `_CONDITION_FIELDS | extra.keys()`, and the `:161` rejection is skipped for any key in `extra`. The evaluator is called at evaluation time with the request context and the extension owns its semantics (`trust_below` reads `subject_trust`, S9).
 
 Open's stricter behaviour is unchanged when `extra` is empty: `trust_below` stays rejected, pinned by the existing test. The paid control test (`test_trust_below_still_supported_here`) moves to the enterprise package unchanged.
+
+**Census correction — the design above named two entry points; the tree has three.** `parse_action_policy` is reached from `local_policy.load_policy` (a policy FILE) *and* from `local_policy.set_policy_dict`, which backs the public `Sensor.set_policy()` runtime API. `load_policy` also does not live in `authz/policy.py` at all. Wiring only what this section named would have left `Sensor(extensions=[...]).set_policy({...})` rejecting the extension's own condition — a live gap in the shipped API, invisible to any test that only loads policies from disk. **This is the S7 lesson repeating for the third time: enumerate sites from the tree, never from a document's line list.** All three now take `extra_conditions`, and `test_set_policy_accepts_an_extension_condition` is the test that would have caught the omission.
+
+**Ordering: S1 had to be split.** The policy is parsed inside `__init__` (`sensor.py`, at the `load_policy` call), but S1's attach block ran at the END of the constructor, so `policy_conditions()` had not been collected when the parser ran. Validation and condition-collection are now "part 1 of 2", hoisted above the policy load; `on_attach` stays last and still receives a fully built sensor. Both halves of S1's contract survive, and the split is commented at both sites.
+
+**The exemption is keyed on the KEY, not on "an extension is present".** `if "trust_below" not in _extra and (...)` — writing it as `if not _extra and (...)` passes every other test in the file and lets `trust_below` through whenever *any* unrelated condition is registered. `test_trust_below_still_rejected_when_a_DIFFERENT_condition_is_registered` is the discriminating case and was proven red against exactly that mis-implementation. (Only its `conditions:` parametrisation discriminates: under `match:`, `trust_below` is caught a second time by the `_MATCH_FIELDS` unknown-key validator.)
+
+Duplicate condition names across two extensions raise at construction naming both extensions and the key, rather than last-write-wins: two packages both believing they own a condition, one silently inert, is the ADV-2 shape.
+
+Measured: corpus oracle byte-identical with no extensions (456 rows, `80f31ff0…`); full suite 7931 → 7951, which is exactly the 20 new tests; skips unchanged at 137.
 
 ### S3 · escalation chain — `scanner/local.py:684` (was H3 + H8)
 
@@ -176,7 +186,7 @@ Per extension per hook per sensor: first fault logs ERROR with extension name, h
 
 1. **S7** enforcement policy object (four sites + grep tripwire). Everything else reads it.
 2. **S1 + S5 + S6** extension object, attach, gate chain, verdict transform, ordering tests. BUILT.
-3. **S2** policy conditions through `parse_action_policy`.
+3. **S2** policy conditions through `parse_action_policy`. BUILT.
 4. **S3** escalation chain in `LocalScanner`, flag-band cap, degraded signal, manifest health.
 5. **S9 + S10 + S11** trust, destination policy, blocked-URL provider.
 6. **S12** egress header consolidation, with `inject_context` wiring as its own commit.

--- a/tests/test_inert_stubs_audit.py
+++ b/tests/test_inert_stubs_audit.py
@@ -295,6 +295,19 @@ def test_scan_paths_never_emit_quarantine_category():
         assert "QUARANTINE_ENFORCED" not in (r.rules or [])
 
 
+def test_bare_sensor_supplies_no_policy_conditions():
+    """A-11, restated for the S2 seam.
+
+    `trust_below` is rejected in open because nothing computes a trust score.
+    S2 makes the condition NAME set extensible, so "open rejects trust_below" is
+    now provable only by showing a bare sensor contributes no condition names at
+    all — an empty map is what keeps `_CONDITION_FIELDS | extra` equal to
+    `_CONDITION_FIELDS` and the trust_below guard unconditional.
+    """
+    s = Sensor(agent_id="a11-s2")
+    assert s.policy_conditions == {}
+
+
 def test_no_gate_other_than_the_circuit_gate_on_a_bare_sensor():
     """A-12, restated for the S5 gate chain.
 

--- a/tests/test_policy_conditions_seam.py
+++ b/tests/test_policy_conditions_seam.py
@@ -1,0 +1,221 @@
+"""S2 · extension-supplied policy condition fields.
+
+The seam lets an enterprise package add names to a rule's ``conditions:`` block
+without forking the parser. What matters most is the case that ships to every
+open user — no extensions — where the parser must behave EXACTLY as it did
+before this seam existed: an unrecognised condition key still rejects the whole
+policy, and ``trust_below`` is still rejected in both placements.
+
+So every test here comes in pairs. The registered half proves the seam works;
+the unregistered half proves open did not move. A test that only demonstrates
+the first is indistinguishable from one asserting something already true.
+
+THREE ENTRY POINTS, not the two the design doc named. `parse_action_policy` is
+reached by `load_policy` (a policy FILE) and by `set_policy_dict` (the public
+`Sensor.set_policy()` runtime API). The doc listed only the first; wiring only
+that one would leave `Sensor(extensions=[...]).set_policy({...})` rejecting the
+extension's own condition. That is the S7 census lesson: enumerate from the
+tree, never from a document's line list.
+"""
+
+import pytest
+
+from xaidr import Sensor, SensorExtension
+from xaidr.authz.policy import parse_action_policy
+from xaidr.local_policy import set_policy_dict
+
+CUSTOM = "geo_outside"
+
+
+def _policy(conditions, rule_id="r1"):
+    return {
+        "version": "1",
+        "defaults": {"effect": "allow", "unclassified": "allow"},
+        "rules": [{"id": rule_id, "effect": "block", "match": {"tools": ["deploy"]},
+                   "conditions": conditions}],
+    }
+
+
+class _GeoExtension(SensorExtension):
+    """Registers one condition name that is NOT trust_below."""
+
+    name = "geo"
+
+    def __init__(self):
+        self.evaluated = []
+
+    def policy_conditions(self):
+        def evaluate(ctx, value):
+            self.evaluated.append((ctx, value))
+            return True
+        return {CUSTOM: evaluate}
+
+
+# ── the parser, directly ─────────────────────────────────────────────────────
+
+def test_unregistered_condition_key_is_rejected():
+    """Open's behaviour, unchanged. This is the half that must not move."""
+    assert parse_action_policy(_policy({CUSTOM: "EU"})) is None
+
+
+def test_registered_condition_key_is_accepted():
+    parsed = parse_action_policy(
+        _policy({CUSTOM: "EU"}), extra_conditions={CUSTOM: lambda ctx, v: True}
+    )
+    assert parsed is not None
+    assert parsed["rules"][0]["conditions"][CUSTOM] == "EU"
+
+
+def test_a_key_registered_by_no_one_still_rejects_alongside_a_registered_one():
+    """Registering one name must not open the gate for every other name."""
+    assert parse_action_policy(
+        _policy({CUSTOM: "EU", "totally_unknown": 1}),
+        extra_conditions={CUSTOM: lambda ctx, v: True},
+    ) is None
+
+
+def test_builtin_condition_fields_still_parse_with_extensions_registered():
+    assert parse_action_policy(
+        _policy({"min_chain_tier_above": 2}),
+        extra_conditions={CUSTOM: lambda ctx, v: True},
+    ) is not None
+
+
+# ── trust_below: the rejection that must survive ─────────────────────────────
+
+@pytest.mark.parametrize("placement", ["conditions", "match"])
+def test_trust_below_still_rejected_with_no_extensions(placement):
+    """A-11 restated for S2. The existing A-11 tests in
+    test_inert_stubs_audit.py are left untouched; this one pins the same
+    behaviour through the new code path."""
+    doc = _policy({"trust_below": 0.5}) if placement == "conditions" else {
+        "version": "1", "defaults": {"effect": "allow"},
+        "rules": [{"id": "r", "effect": "block", "match": {"trust_below": 0.5}}],
+    }
+    assert parse_action_policy(doc) is None
+
+
+@pytest.mark.parametrize("placement", ["conditions", "match"])
+def test_trust_below_still_rejected_when_a_DIFFERENT_condition_is_registered(placement):
+    """The discriminating case: registering `geo_outside` must not exempt
+    `trust_below`. An exemption keyed on "any extension present" rather than on
+    the KEY would pass every other test in this file and fail this one."""
+    doc = _policy({"trust_below": 0.5}) if placement == "conditions" else {
+        "version": "1", "defaults": {"effect": "allow"},
+        "rules": [{"id": "r", "effect": "block", "match": {"trust_below": 0.5}}],
+    }
+    assert parse_action_policy(
+        doc, extra_conditions={CUSTOM: lambda ctx, v: True}
+    ) is None
+
+
+def test_an_extension_that_registers_trust_below_may_use_it():
+    """S9 is what supplies the score; this only proves the guard is keyed on the
+    name, so the enterprise package can take ownership of it."""
+    assert parse_action_policy(
+        _policy({"trust_below": 0.5}),
+        extra_conditions={"trust_below": lambda ctx, v: True},
+    ) is not None
+
+
+# ── the sensor, through both runtime entry points ────────────────────────────
+
+def test_bare_sensor_has_no_policy_conditions():
+    assert Sensor(agent_id="s2-bare").policy_conditions == {}
+
+
+def test_sensor_collects_conditions_from_its_extensions():
+    s = Sensor(agent_id="s2-ext", extensions=[_GeoExtension()])
+    assert list(s.policy_conditions) == [CUSTOM]
+
+
+def test_set_policy_accepts_an_extension_condition():
+    """The entry point the design doc missed. `set_policy` goes through
+    `set_policy_dict`, not `load_policy`."""
+    s = Sensor(agent_id="s2-set", extensions=[_GeoExtension()])
+    assert s.set_policy(_policy({CUSTOM: "EU"})) is True
+
+
+def test_set_policy_rejects_the_same_policy_on_a_bare_sensor():
+    """The negative half of the test above, and the one that shows the seam is
+    doing the work rather than the key having become globally valid."""
+    assert Sensor(agent_id="s2-set-bare").set_policy(_policy({CUSTOM: "EU"})) is False
+
+
+def test_set_policy_dict_forwards_extra_conditions():
+    assert set_policy_dict(_policy({CUSTOM: "EU"})) is None
+    assert set_policy_dict(
+        _policy({CUSTOM: "EU"}), extra_conditions={CUSTOM: lambda ctx, v: True}
+    ) is not None
+
+
+def test_policy_file_path_forwards_extra_conditions(tmp_path):
+    """The entry point the doc DID name, proved separately from set_policy."""
+    yaml = pytest.importorskip("yaml")
+    path = tmp_path / "xaidr-policy.yaml"
+    # load_policy hands the file's top-level document straight to the parser.
+    path.write_text(yaml.safe_dump(_policy({CUSTOM: "EU"})), encoding="utf-8")
+    from xaidr.local_policy import load_policy
+    assert load_policy(str(path)) is None
+    assert load_policy(
+        str(path), extra_conditions={CUSTOM: lambda ctx, v: True}
+    ) is not None
+
+
+# ── duplicate condition names across extensions ──────────────────────────────
+
+def test_two_extensions_declaring_the_same_condition_raise_at_construction():
+    class Alpha(SensorExtension):
+        name = "alpha"
+
+        def policy_conditions(self):
+            return {"shared": lambda ctx, v: True}
+
+    class Beta(SensorExtension):
+        name = "beta"
+
+        def policy_conditions(self):
+            return {"shared": lambda ctx, v: True}
+
+    with pytest.raises(ValueError) as exc:
+        Sensor(agent_id="s2-dup", extensions=[Alpha(), Beta()])
+    message = str(exc.value)
+    assert "alpha" in message and "beta" in message, (
+        "the error must name BOTH extensions, or the operator cannot tell which "
+        "pair collided"
+    )
+    assert "shared" in message
+
+
+def test_distinct_condition_names_across_extensions_merge():
+    class Alpha(SensorExtension):
+        name = "alpha"
+
+        def policy_conditions(self):
+            return {"cond_a": lambda ctx, v: True}
+
+    class Beta(SensorExtension):
+        name = "beta"
+
+        def policy_conditions(self):
+            return {"cond_b": lambda ctx, v: True}
+
+    s = Sensor(agent_id="s2-merge", extensions=[Alpha(), Beta()])
+    assert sorted(s.policy_conditions) == ["cond_a", "cond_b"]
+
+
+def test_policy_conditions_returning_a_non_mapping_raises():
+    class Bad(SensorExtension):
+        name = "bad"
+
+        def policy_conditions(self):
+            return ["not", "a", "mapping"]
+
+    with pytest.raises(ValueError, match="policy_conditions"):
+        Sensor(agent_id="s2-bad", extensions=[Bad()])
+
+
+def test_the_property_is_a_copy():
+    s = Sensor(agent_id="s2-copy", extensions=[_GeoExtension()])
+    s.policy_conditions["injected"] = lambda ctx, v: True
+    assert "injected" not in s.policy_conditions

--- a/xaidr/authz/policy.py
+++ b/xaidr/authz/policy.py
@@ -22,7 +22,7 @@ import difflib
 import fnmatch
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 logger = logging.getLogger("xaidr.authz")
 
@@ -117,7 +117,11 @@ class AuthzDecision:
 MONITOR_DECISION = AuthzDecision(decision="monitor")
 
 
-def parse_action_policy(raw: Any) -> Optional[dict]:
+def parse_action_policy(
+    raw: Any,
+    *,
+    extra_conditions: Optional[Mapping[str, Any]] = None,
+) -> Optional[dict]:
     """Validate and normalize an action_policy payload.
 
     Returns the normalized policy dict, or None for anything malformed —
@@ -129,6 +133,13 @@ def parse_action_policy(raw: Any) -> Optional[dict]:
     elsewhere (top level, rule level) remain ignored — those do not disarm
     anything.
     """
+    # S2 · extension-supplied condition names. Resolved ONCE, here, so the two
+    # places below that consult it cannot drift apart. Empty for every caller
+    # that does not pass it, which is what makes this seam a no-op in open:
+    # `_condition_fields` is then `_CONDITION_FIELDS` and the trust_below guard
+    # is unconditional, exactly as before.
+    _extra: Mapping[str, Any] = extra_conditions or {}
+    _condition_fields = _CONDITION_FIELDS | set(_extra)
     try:
         if not isinstance(raw, dict):
             return None
@@ -158,7 +169,14 @@ def parse_action_policy(raw: Any) -> Optional[dict]:
             # Only `conditions.trust_below` is ever read at evaluation time, so a
             # rule that puts it under `match:` (the placement the README shows) is
             # exactly the silent no-op this guard exists to prevent.
-            if "trust_below" in conditions or "trust_below" in match:
+            # S2: an extension that REGISTERED `trust_below` has supplied the
+            # per-agent trust score this rejection exists to protect against, so
+            # the rule can fire and the guard does not apply. With no extension
+            # registered `_extra` is empty and this reads exactly as it did
+            # before the seam: the rejection below is unchanged for open.
+            if "trust_below" not in _extra and (
+                "trust_below" in conditions or "trust_below" in match
+            ):
                 logger.error(
                     "[xaidr] action_policy rule %r uses 'trust_below' (under "
                     "'conditions:' or 'match:' — both are rejected), which "
@@ -174,7 +192,9 @@ def parse_action_policy(raw: Any) -> Optional[dict]:
             # Checked AFTER trust_below so that key keeps its specific message.
             if _reject_unknown_keys(r.get("id"), "match", match, _MATCH_FIELDS.keys()):
                 return None
-            if _reject_unknown_keys(r.get("id"), "conditions", conditions, _CONDITION_FIELDS):
+            if _reject_unknown_keys(
+                r.get("id"), "conditions", conditions, _condition_fields
+            ):
                 return None
             rules.append({
                 "id": str(r.get("id")) if r.get("id") is not None else None,

--- a/xaidr/local_policy.py
+++ b/xaidr/local_policy.py
@@ -51,7 +51,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from .authz.policy import (
     AuthzDecision,
@@ -82,6 +82,7 @@ def load_policy(
     policy_file: Optional[str] = None,
     *,
     auto_default: bool = True,
+    extra_conditions: Optional[Mapping[str, Any]] = None,
 ) -> Optional[dict]:
     """Load and parse a policy from a file (or the conventional default).
 
@@ -114,7 +115,7 @@ def load_policy(
         logger.warning("[xaidr] could not read policy file %s: %s (detection-only)", path, exc)
         return None
 
-    policy = parse_action_policy(raw)
+    policy = parse_action_policy(raw, extra_conditions=extra_conditions)
     if policy is None:
         logger.warning(
             "[xaidr] policy file %s is malformed or unsupported; "
@@ -126,9 +127,19 @@ def load_policy(
     return policy
 
 
-def set_policy_dict(raw: Any) -> Optional[dict]:
-    """Parse a policy supplied programmatically as a dict. Fail-safe (None on bad)."""
-    policy = parse_action_policy(raw)
+def set_policy_dict(
+    raw: Any,
+    *,
+    extra_conditions: Optional[Mapping[str, Any]] = None,
+) -> Optional[dict]:
+    """Parse a policy supplied programmatically as a dict. Fail-safe (None on bad).
+
+    Takes `extra_conditions` for the same reason `load_policy` does: this backs
+    the public `Sensor.set_policy()`, so a policy set at RUNTIME must accept the
+    same extension-supplied condition names a policy FILE would. The seam design
+    named only `load_policy`; the grep found this one too.
+    """
+    policy = parse_action_policy(raw, extra_conditions=extra_conditions)
     if policy is None:
         logger.warning("[xaidr] set_policy: malformed policy ignored (detection-only)")
     return policy

--- a/xaidr/sensor.py
+++ b/xaidr/sensor.py
@@ -11,7 +11,7 @@ import json
 import logging
 import time
 from dataclasses import replace
-from typing import Optional, Sequence
+from typing import Mapping, Optional, Sequence
 from uuid import uuid4
 
 # NOTE: httpx is an OPTIONAL dependency, imported lazily only when the HTTP-
@@ -513,10 +513,44 @@ class DelphiSensor:
             str(u) for u in (blocked_urls or ()) if u
         ]
 
+        # ── S1 · attach, part 1 of 2: validate + collect ──────────────────
+        # BEFORE the policy load below, because S2 lets an extension supply
+        # condition names and `parse_action_policy` has to know them at parse
+        # time. on_attach still runs LAST (see part 2 at the end of __init__).
+        #
+        # Validated the way circuit_breaker above is validated, and for the same
+        # reason (ADV-2): a security control handed something it does not
+        # understand must fail at construction, not default to inert.
+        #
+        # `extensions` is normalised to a tuple so a caller that keeps and
+        # mutates its list afterwards cannot change what this sensor runs.
+        if isinstance(extensions, (str, bytes)) or not isinstance(
+            extensions, (list, tuple)
+        ):
+            raise ValueError(
+                "extensions must be a list or tuple of SensorExtension "
+                f"instances, got {type(extensions).__name__}"
+            )
+        for index, extension in enumerate(extensions):
+            if not isinstance(extension, SensorExtension):
+                raise ValueError(
+                    f"extensions[{index}] must be a SensorExtension instance, "
+                    f"got {type(extension).__name__}"
+                )
+        self._extensions: tuple = tuple(extensions)
+        #: (extension name, hook name) pairs whose fault has already been
+        #: reported, so a broken hook is stated ONCE per sensor rather than
+        #: once per scan. Same discipline as ``_breaker_faults``.
+        self._extension_faults: set = set()
+        #: S2 · the merged extension-supplied policy condition evaluators.
+        self._policy_conditions: dict = self._collect_policy_conditions()
+
         # Local YAML policy source (no backend). None if absent/malformed —
         # load_policy fails safe and logs what it loads. Auto-loads
         # ./xaidr-policy.yaml when no explicit file is given.
-        self._policy = _policy.load_policy(policy_file)
+        self._policy = _policy.load_policy(
+            policy_file, extra_conditions=self._policy_conditions
+        )
 
         # A2A structural validation (Tier A, content-blind) + local id tracking
         # (Tier B, LOCAL ONLY — catches references to ids this sensor never
@@ -558,35 +592,17 @@ class DelphiSensor:
                 )
                 self._breaker._emit_hook = self._emit_circuit_event
 
-        # ── S1 · attach ──────────────────────────────────────────────────
+        # ── S1 · attach, part 2 of 2: on_attach ──────────────────────────
         # LAST in the constructor, deliberately: on_attach receives a fully
         # built sensor, so an extension may read the breaker, the policy and
         # the reporter it is being installed alongside.
         #
-        # Validated the way circuit_breaker above is validated, and for the same
-        # reason (ADV-2): a security control handed something it does not
-        # understand must fail at construction, not default to inert.
-        #
-        # `extensions` is normalised to a tuple so a caller that keeps and
-        # mutates its list afterwards cannot change what this sensor runs.
-        if isinstance(extensions, (str, bytes)) or not isinstance(
-            extensions, (list, tuple)
-        ):
-            raise ValueError(
-                "extensions must be a list or tuple of SensorExtension "
-                f"instances, got {type(extensions).__name__}"
-            )
-        for index, extension in enumerate(extensions):
-            if not isinstance(extension, SensorExtension):
-                raise ValueError(
-                    f"extensions[{index}] must be a SensorExtension instance, "
-                    f"got {type(extension).__name__}"
-                )
-        self._extensions: tuple = tuple(extensions)
-        #: (extension name, hook name) pairs whose fault has already been
-        #: reported, so a broken hook is stated ONCE per sensor rather than
-        #: once per scan. Same discipline as ``_breaker_faults``.
-        self._extension_faults: set = set()
+        # Validation and policy_conditions() collection happen EARLIER (see
+        # "S1 · attach, part 1 of 2" above), because the policy is parsed at
+        # construction and the parser needs the extension-supplied condition
+        # names before it runs. Splitting the seam is what keeps both true:
+        # conditions are known before the policy loads, and on_attach still
+        # sees a finished object.
         for extension in self._extensions:
             # NOT wrapped: a fault here is a construction failure and raises.
             # See SensorExtension.on_attach for why this one hook is different.
@@ -601,6 +617,54 @@ class DelphiSensor:
     def extensions(self) -> tuple:
         """The attached extensions, in the order they will be called."""
         return self._extensions
+
+    @property
+    def policy_conditions(self) -> dict:
+        """S2 · extension-supplied `conditions:` evaluators, by field name.
+
+        Empty on a bare sensor, which is what keeps the open parser's behaviour
+        identical: an unregistered condition key still rejects exactly as before.
+        """
+        return dict(self._policy_conditions)
+
+    def _collect_policy_conditions(self) -> dict:
+        """Merge every extension's `policy_conditions()` into one map.
+
+        A DUPLICATE key across two extensions RAISES at construction rather than
+        letting one win. Silent last-write-wins is the ADV-2 shape: two packages
+        both believe they own `trust_below`, one is quietly inert, and the
+        deployment cannot tell which. The message names both extensions and the
+        key so the collision is actionable without reading either package.
+
+        Not wrapped in the fail-safe hook handler for the same reason on_attach
+        is not: this runs at CONSTRUCTION, and a mis-declared condition set is an
+        install error, not a runtime fault.
+        """
+        merged: dict = {}
+        owner: dict = {}
+        for extension in self._extensions:
+            name = getattr(extension, "name", type(extension).__name__)
+            conditions = extension.policy_conditions()
+            if not conditions:
+                continue
+            if not isinstance(conditions, Mapping):
+                raise ValueError(
+                    f"extension {name!r} returned {type(conditions).__name__} "
+                    "from policy_conditions(); expected a mapping of "
+                    "{condition_name: evaluator}"
+                )
+            for key, evaluator in conditions.items():
+                if key in merged:
+                    raise ValueError(
+                        f"extensions {owner[key]!r} and {name!r} both declare "
+                        f"the policy condition {key!r}. Two extensions cannot "
+                        "own the same condition name: one would silently win "
+                        "and the other's control would be inert. Rename one, or "
+                        "attach only one of them."
+                    )
+                merged[key] = evaluator
+                owner[key] = name
+        return merged
 
     def _extension_failed(self, extension, hook: str, exc: Exception) -> None:
         """Report a fault inside an extension hook. ONCE per extension per hook.
@@ -996,7 +1060,13 @@ class DelphiSensor:
         if policy is None:
             self._policy = None
             return False
-        parsed = _policy.set_policy_dict(policy)
+        # Same extension conditions the constructor parsed with: a policy set
+        # at runtime must accept exactly the keys a policy FILE would have.
+        # Missing this is how set_policy() would reject an extension's own
+        # condition on a sensor that was built to understand it.
+        parsed = _policy.set_policy_dict(
+            policy, extra_conditions=self._policy_conditions
+        )
         self._policy = parsed
         return parsed is not None
 


### PR DESCRIPTION
PR 3 of the enterprise-seam sequencing (S7 → #4, S1+S5+S6 → #5). An extension may now add names to a rule's `conditions:` block without forking the parser.

## What lands

`parse_action_policy(raw, *, extra_conditions=None)`. Inside, resolved once:

```python
_extra = extra_conditions or {}
_condition_fields = _CONDITION_FIELDS | set(_extra)
```

- the unknown-key validator consults `_condition_fields` instead of `_CONDITION_FIELDS`
- the `trust_below` hard rejection becomes `if "trust_below" not in _extra and (...)`

`DelphiSensor.__init__` collects `policy_conditions()` from every attached extension, merges them, and forwards the map. Exposed read-only as `Sensor.policy_conditions`.

## The census found a third entry point the design doc missed

The doc named `parse_action_policy` and `load_policy`. The tree has **three** paths to the parser, and `load_policy` isn't even in `authz/policy.py`:

| Path | Location | In the doc? |
|---|---|---|
| `load_policy` (policy **file**) | `local_policy.py:81` → `:118` | named, but wrong module |
| **`set_policy_dict`** (backs public `Sensor.set_policy()`) | `local_policy.py:129` → `:142` | **missed entirely** |
| `parse_action_policy` | `authz/policy.py:120` | named |

Wiring only what the doc named would have left `Sensor(extensions=[...]).set_policy({...})` **rejecting the extension's own condition** — a live gap in the shipped API, invisible to any test that only loads policies from disk. All three now forward. This is the S7 census lesson for the third time: enumerate from the tree, never from a document's line list.

## S1 had to be split

The policy parses inside `__init__` at the `load_policy` call, but S1's attach block ran at the **end** of the constructor — `policy_conditions()` had not been collected when the parser ran. Validation and collection are now "part 1 of 2", hoisted above the policy load; `on_attach` stays last and still receives a fully built sensor. Both halves of S1's contract survive, and the split is commented at both sites.

## trust_below's rejection is unmodified

The existing A-11 tests in `test_inert_stubs_audit.py` are **untouched** — no assertion edited — and green. With zero extensions the parser is byte-for-byte equivalent: `_extra` is empty, `_condition_fields == _CONDITION_FIELDS`, and the `trust_below` guard is unconditional.

**The exemption is keyed on the KEY, not on "an extension is present."** Written as `if not _extra and (...)` it passes every other test in this file and lets `trust_below` through whenever *any* unrelated condition is registered. That mis-implementation was built and proven red:

```
SABOTAGE: exemption keyed on 'any extension present' instead of on the KEY
E   AssertionError: assert {... 'conditions': {'trust_below': 0.5} ...} is None
E    +  where ... = parse_action_policy(..., extra_conditions={'geo_outside': <lambda>})
FAILED ...::test_trust_below_still_rejected_when_a_DIFFERENT_condition_is_registered[conditions]
```

Only the `conditions:` parametrisation discriminates — under `match:`, `trust_below` is caught a second time by the `_MATCH_FIELDS` unknown-key validator.

## Duplicate condition names

Two extensions declaring the same condition **raise at construction**, naming both extensions and the key:

```
extensions 'alpha' and 'beta' both declare the policy condition 'dup'. Two
extensions cannot own the same condition name: one would silently win and the
other's control would be inert. Rename one, or attach only one of them.
```

Last-write-wins would be the ADV-2 shape — two packages both believing they own a condition, one silently inert, with no way to tell which.

## Counts

```
full suite   clean origin/main (c3bf060) : 7931 passed / 137 skipped
             this branch                 : 7951 passed / 137 skipped
             +20 = exactly the new tests (19 S2 + 1 inert-stubs); skips unchanged

corpus oracle  456 rows sha256=80f31ff0b5d5f107...f10a1bb8  — identical to clean
               main; row count asserted by the gate itself, not hardcoded here

existing policy tests  106 passed, unmodified (inert-stubs, privilege tiers,
                       mcp-server policy match)
```

## Failing-first

Seven sabotages, each red on the right test. All runs used `PYTHONDONTWRITEBYTECODE=1` plus a `__pycache__` purge — per the S7 lesson, equal-length edits leave file size unchanged and mtime granularity can silently hand back the previous iteration's `.pyc`.

```
sensor drops the merged conditions          -> 5 failed
set_policy stops forwarding                 -> test_set_policy_accepts_an_extension_condition
load_policy stops forwarding                -> test_policy_file_path_forwards_extra_conditions
trust_below exemption reverted              -> test_an_extension_that_registers_trust_below_may_use_it
unknown-key validator ignores extra         -> 4 failed
duplicate-key detection removed             -> test_two_extensions_declaring_the_same_condition_raise
exemption keyed on "any extension present"  -> test_trust_below_still_rejected_when_a_DIFFERENT_...
```

Restored: `19 passed`.

## Not verified from outside the process

All evidence above is in-process (`pytest`, the oracle script). No deployed artifact and no readiness signal distinguishes "S2 present" from "S2 absent" on a running Brain, so external verification is deferred by construction — same standing gap as #5. The manifest listing attached extensions and their registered condition names would close it.
