### PR TITLE
docs(release): write down the release process, and gate it from outside the tree

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,92 @@
+name: release gate
+
+# A version tag with no published release object is a release that was never
+# cut. The notes exist only in the release commit body, where nobody watching
+# the repository sees them -- which is the state this repo was in on
+# 2026-09-09: fifteen tags, zero releases.
+#
+# WHY THIS IS A SEPARATE WORKFLOW FROM ci.yml. ci.yml proves the TREE is
+# self-consistent: it runs pytest and the corpus report against a checkout. It
+# has no running Brain, no credentials, no database and no view of GitHub, and
+# a green run there says nothing about server-side state. This workflow reads
+# GitHub's API for BOTH sides of the comparison -- the tag list and the release
+# list -- so it is an outside-the-process check in the sense that matters:
+# nothing in the checkout can make it pass.
+#
+# `actions/checkout` is here only to fetch the script. Its default fetch-depth
+# of 1 pulls no tags at all, and that is left deliberately unchanged: if this
+# job ever starts reading `git tag`, the missing tags will make it fail loudly
+# rather than quietly measure the runner instead of the repository.
+
+on:
+  push:
+    tags:
+      - "v*"
+  # The backstop. The tag-push job only ever sees the tag being pushed, so it
+  # cannot notice a release object deleted, un-published, or never created for
+  # some earlier tag. This sweep re-checks every tag at or above the floor.
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+    inputs:
+      floor:
+        description: "Lowest tag to check (vMAJOR.MINOR.PATCH)"
+        required: false
+        default: "v1.10.0"
+
+concurrency:
+  group: release-gate-${{ github.ref }}
+  cancel-in-progress: false
+
+# The gate reads public metadata and writes nothing.
+permissions:
+  contents: read
+
+jobs:
+  # ── the tag that was just pushed ───────────────────────────────────────────
+  # docs/releasing.md step 4 puts release creation IMMEDIATELY after the tag
+  # push, so the tag reaches GitHub a moment before the release does. That gap
+  # is real and this job waits it out -- `--wait-seconds 600`, ten minutes of
+  # grace, then it FAILS. It is a bounded grace, not a retry-until-green loop:
+  # a job that polls until it passes is a job that cannot fail.
+  pushed-tag:
+    name: "${{ github.ref_name }} has a published release object"
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # No `pip install` of anything, including this package. The gate is
+      # stdlib-only on purpose: it must still run on a tag whose wheel does not
+      # build, which is exactly when you most want to know the release is
+      # incomplete.
+      - name: Gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/release_objects_gate.py \
+            --tag "${{ github.ref_name }}" \
+            --wait-seconds 600
+
+  # ── every tag at or above the floor ────────────────────────────────────────
+  sweep:
+    name: every tag at or above the floor
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/release_objects_gate.py \
+            --floor "${{ inputs.floor || 'v1.10.0' }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,26 @@ The one passage that still blocks, `bp-055`, is documented by ID with its cause
 in `tests/test_benign_prose.py` rather than suppressed, so that a second one
 shows up as a new entry instead of disappearing into a percentage.
 
+## Cutting a release (maintainers)
+
+Nothing in this section is something an outside contributor can do — it needs
+push access to tags and a token — which is why it lives in
+[`docs/releasing.md`](docs/releasing.md) rather than here.
+
+Two things about it are worth knowing even if you never cut one, because they
+change what a pull request is expected to carry:
+
+- **A tag is not a release.** The release object is created as part of cutting
+  the release, and `.github/workflows/release-gate.yml` fails a `v*` tag push
+  that has no published release behind it. That gate reads GitHub's API rather
+  than the checkout, so it is the one check here that a green tree cannot make
+  pass.
+- **U-1: no figure without a regenerator.** Any number you put in a release
+  body, in `README.md`, or in `docs/` needs a committed script that recomputes
+  it, named alongside it. This applies to your pull request too — it is the same
+  rule as [Every detection change is measured](#every-detection-change-is-measured),
+  extended to every published figure rather than just the corpus tables.
+
 ## Code of conduct
 
 This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Reports go

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,266 @@
+# Cutting a release
+
+_Part of the [xaidr](https://github.com/delphisecurity/xaidr/blob/main/README.md) documentation._
+
+This is the maintainer procedure for cutting a release. It is written down
+because the parts of it that were only ever in a working session are the parts
+that went wrong.
+
+On 2026-09-09 this repository had **fifteen tags and zero release objects**. The
+notes for every one of those releases — including a webhook credential leak that
+required anyone on 1.13.0 or 1.14.0 to rotate a secret, and a CrewAI boundary
+that 1.6.1 reported as PATCHED while a destructive tool call executed anyway —
+existed only inside a release commit body. `git log` had them. Nobody watching
+the repository was told any of it. Every CI run was green the entire time,
+because nothing in CI could see server-side state.
+
+**A tag is not a release.** The release object is the artifact a consumer reads;
+creating it is step 5, not a follow-up.
+
+## The five steps
+
+### 1. Reconcile the notes against the range
+
+Write the notes in the release commit body. Then, before anything else, print
+the range they claim to describe:
+
+```
+git log --oneline <previous-tag>..HEAD
+```
+
+Tick every line as **described** or **deliberately silent**. Not "skimmed" —
+ticked, one line at a time, in the pull request.
+
+This is the step that failed at 1.15.0. The notes were drafted, PR #5 merged
+after they were drafted, and the release shipped describing the resource-bound
+detector only. Three of the seven commits in the range — the `SensorExtension`
+seam, the monitor-mode field-loss fix, and the per-site fail-open sabotage —
+went out undescribed, and one of them changes what a monitor-mode sensor returns
+to its caller. **Notes written before the last merge are notes about a different
+release.**
+
+Then check every commit SHA the notes cite:
+
+```
+for sha in $(grep -oE '\b[0-9a-f]{7,40}\b' notes.md); do
+  git merge-base --is-ancestor "$sha" HEAD || echo "NOT AN ANCESTOR: $sha"
+done
+```
+
+1.15.0's notes cite `a64207e` and `64ec128` for the two false-positive fixes.
+Both live on an unmerged branch and neither is an ancestor of the tag; the
+commits that shipped are `909b8dd` and `c31d10f`. A reader who tries to look
+them up gets nothing.
+
+### 2. Tag locally. Do not push yet
+
+```
+git tag -a "v$VERSION" -F notes.md
+```
+
+The tag is created before the verification below because the verification builds
+*from the tag*, and it is not pushed until the verification passes. A pushed tag
+is public and a release you have not verified should not be.
+
+### 3. Build from a clean clone of the tag, and verify from the artifact
+
+Not from the working tree, and not from an editable install. The tree is what
+you have been editing; the artifact is what a consumer gets, and the two differ
+in ways that only show up here — `docs/` ships in neither artifact, the wheel is
+`packages = ["xaidr"]` and the sdist is `["xaidr", "README.md", "pyproject.toml"]`.
+
+```
+git clone --branch "v$VERSION" --single-branch . /tmp/rel && cd /tmp/rel
+python -m build
+python -m venv /tmp/relvenv && /tmp/relvenv/bin/pip install dist/*.whl
+```
+
+Then verify **at a neutral cwd, with `xaidr.__file__` asserted inside
+site-packages**:
+
+```
+cd / && /tmp/relvenv/bin/python -I -c "
+import xaidr
+assert 'site-packages' in xaidr.__file__, xaidr.__file__
+print(xaidr.__version__, xaidr.__file__)
+"
+```
+
+Both halves are load-bearing and neither is optional:
+
+- **Neutral cwd + `python -I`.** Run from the source tree, Python puts the
+  source tree on `sys.path` and imports `./xaidr/` in preference to the
+  installed package. Every claim you then make is about the tree you were just
+  editing, wearing the version number of the artifact.
+- **`xaidr.__file__` in site-packages.** This is the assertion that catches it.
+  Printing the version does not: `xaidr.__version__` is the same string in both,
+  which is exactly why a version check reads as a verification while performing
+  none.
+
+Anything the notes claim about the shipped package — a redaction, a boundary, a
+refusal shape — is measured here, in this interpreter, and the output is pasted.
+
+### 4. Prove detection did not move, and name every change that did
+
+The claim to make is **byte-identical, with every intended change named**, and
+it is made against the *published* previous wheel, not the previous worktree:
+
+```
+pip download "xaidr==$PREVIOUS" --no-deps -d /tmp/prev
+```
+
+Scan the corpus under both wheels on all four boundaries — input, output, tool,
+A2A — and compare `action`, `score`, `category` and the **ordered rule list**
+value for value. One digest over the whole set is the summary; the diff is the
+evidence. Then:
+
+- **If nothing moved**, say so with the digest and the row count.
+- **If something moved, enumerate it in full.** 1.15.0 moved eleven verdicts and
+  listed all eleven with the rule that caused each. 1.14.1 moved twelve and
+  listed twelve. That is the standard: a count without the rows is a number a
+  reader cannot check.
+- **Report residual false positives as a number, never as "clean".** 1.15.0
+  ships at 2 of 50 on the discriminator pool and says so, because 2 is what it
+  is.
+- **Name the pool that could not see the class.** Both of 1.14.1's fixes were
+  invisible to the 190-call benign corpus by construction. "0/190" was true and
+  meaningless for the entire time the detector was flagging a fifth of realistic
+  traffic.
+
+### 5. Push the tag, then create the release object
+
+In that order, minutes apart. The release object is extracted from the commit
+body — not retyped, not summarised:
+
+```
+git push origin "v$VERSION"
+
+git show -s --format=%b "v$VERSION" \
+  | sed '/^\(Co-Authored-By\|Claude-Session\|Signed-off-by\):/d' > /tmp/notes.md
+
+gh release create "v$VERSION" --verify-tag \
+  --title "v$VERSION — <one line>" --notes-file /tmp/notes.md
+```
+
+Three things about the body:
+
+- **`--notes-file`, always.** Retyping is how a release note drifts from the
+  commit it describes.
+- **Fence the column-aligned blocks.** Verdict diffs, suite tables and pasted
+  interpreter output are aligned with spaces; GitHub-flavoured Markdown strips
+  leading indent and collapses runs of spaces, so an unfenced evidence table
+  renders as ragged prose. The bodies are the evidence — losing their alignment
+  loses the point of them.
+- **Security content gets said in the title.** `Security:` plus the affected
+  versions, a banner above the body naming the action a reader must take, and a
+  GHSA advisory if it warrants one. Five of this project's releases were
+  security releases and none of them said so anywhere a consumer would look:
+  v1.4.1, v1.6.2, v1.11.0, v1.13.0, v1.14.1.
+
+Finally, paste the proof:
+
+```
+gh release view "v$VERSION" --json tagName,isDraft,publishedAt,htmlUrl
+```
+
+## U-1 — no figure without a regenerator
+
+**No number ships in a release body, in `README.md`, or in any `docs/` page
+unless a committed script regenerates it, and the release body names that
+script.**
+
+Not "a script exists somewhere". Not "it was measured". A path in this
+repository that a reader can run.
+
+This rule has a measured cost of being absent. Seven distinct hex digests are
+cited across six release bodies — v1.9.0, v1.10.0, v1.11.0, v1.12.0, v1.13.0 and
+v1.14.0 — as the proof that detection did not move:
+
+```
+v1.9.0    25606dd56cbbadb9024310be2ae39921216fe114286b87febca789a52fb1ad02
+v1.9.0    bb8e8502                                    (wheel digest, truncated)
+v1.10.0   9e2d30012258e6cd38d586be2f6963d3640f51cb3979129714ff29a907a7ec19
+v1.10.0   cf1f8a4f                                    (wheel digest, truncated)
+v1.11.0   9e2d30012258e6cd38d586be2f6963d3640f51cb3979129714ff29a907a7ec19
+v1.11.0   a9503119                                    (wheel digest, truncated)
+v1.12.0   d02a18b56e31dd02e44c76eb78b9fd1c0d6cae958e87447fe9aa50ec9c78253b
+v1.13.0   d02a18b56e31dd02e44c76eb78b9fd1c0d6cae958e87447fe9aa50ec9c78253b
+v1.14.0   36a80b7aa52fbd8430428eeb8c6e3e920dc3923bca176738c6ec62434c213d78
+```
+
+**Not one of them has ever appeared in a committed file, on any branch, at any
+point in this repository's history.** `git log --all -S<digest> --pickaxe-all`
+finds nothing for all seven. No script in `scripts/` computes a corpus verdict
+digest at all.
+
+So the strongest evidence these releases offer — the thing the phrase
+"BYTE-IDENTICAL" rests on — cannot be reproduced, cannot be disproved, and
+cannot be told apart from a number that was typed. That is worse than omitting
+it: an unreproducible digest reads as rigour and supplies none, which is the
+same failure as a `content_hash` computed from the tool name, or a `/health`
+endpoint answering with a hardcoded literal.
+
+The rule is one sentence with one exception, and the exception is stated in
+public:
+
+- A figure with a regenerator names it: `python scripts/corpus_report.py`,
+  `python scripts/intent_metrics.py`, `python scripts/asi_battery_report.py`,
+  `python scripts/heldout_report.py`, `python scripts/benign_toolcall_report.py`.
+- A figure whose regenerator would leak a working set of attacks that defeat the
+  shipped rules is **withheld with that reason given**, as `heldout/` already
+  does. Withheld is honest. Unreproducible-but-quoted is not.
+- A figure that could not be measured in this environment is **withdrawn, not
+  restated**. 1.15.0 did this correctly with the rules+nano column: the `nano`
+  extra was absent, the stale 55/120 was withdrawn rather than repeated, and the
+  regeneration command was named.
+
+The debt this creates is a corpus-digest regenerator that does not yet exist.
+Until it does, a release body claiming byte-identical detection names the wheels
+compared, the pools, the row count and the boundaries — and does **not** publish
+a digest nobody can recompute.
+
+## The gate
+
+`scripts/release_objects_gate.py` fails if a version tag exists with no
+published release object. `.github/workflows/release-gate.yml` runs it on every
+`v*` tag push, on a daily schedule, and on demand.
+
+**It reads GitHub's API for both sides of the comparison** — the tag list and
+the release list — and never `git tag`. That is the property worth having.
+`ci.yml` proves the tree is self-consistent; it has no view of GitHub, and the
+fifteen-tags-zero-releases state was invisible to it for months while it stayed
+green. A gate that compared a local tag list against a remote release list would
+be measuring the runner: `actions/checkout` fetches no tags by default, so the
+tempting shortcut passes vacuously on an empty set.
+
+What counts:
+
+- **A draft does not count.** A draft is what an interrupted release leaves
+  behind. It is invisible to non-maintainers and notifies nobody.
+- **Tags below `--floor` (default `v1.10.0`) are reported and skipped**, not
+  silently dropped — the run prints them, so the output cannot read as full
+  coverage. The floor is where this process took effect. A floor is used rather
+  than a grandfathered list because an exception list never shrinks; a floor is
+  monotone and every future tag is above it.
+- **Exit 2 is "could not run", distinct from 0 and 1**, so a rate limit or an
+  auth failure can never be mistaken for a pass.
+
+Run it yourself at any time:
+
+```
+python scripts/release_objects_gate.py                 # every tag >= floor
+python scripts/release_objects_gate.py --floor v1.0.0  # include the pre-policy tags
+```
+
+`tests/test_release_objects_gate.py` covers the comparison, and each of its
+discriminating cases has been shown to fail against a sabotaged gate — the draft
+filter, the vacuous-pass guard, the exit-2 path, version ordering, and the
+below-floor report. The network half is not testable in pytest by construction
+and is verified by running the script against the live API.
+
+At the time of writing the gate is green at its floor and red at `--floor
+v1.0.0`, which names the six pre-policy tags that still have no release object:
+v1.5.0, v1.6.0, v1.6.1, v1.7.0, v1.8.0, v1.9.0. Those were left uncut
+deliberately — a docs-only republish and an internal evidence correction are
+noise as release events — and the floor records that decision rather than hiding
+it.

--- a/scripts/release_objects_gate.py
+++ b/scripts/release_objects_gate.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Fail if a version tag exists on GitHub with no published release object.
+
+WHY THIS READS THE API AND NOT THE TREE.
+
+Every other guard in this repository proves the tree is self-consistent. This
+one cannot, because the thing it is checking does not live in the tree: a
+release object is server-side state, and the failure it exists to catch --
+fifteen tags and zero releases, which is the state this repo was in on
+2026-09-09 -- is invisible to `git tag`, to pytest, and to every CI job that
+only ever looks at a checkout. So BOTH sides of the comparison are fetched from
+GitHub:
+
+    tags     GET /repos/{repo}/tags
+    releases GET /repos/{repo}/releases
+
+`git tag` is deliberately NOT used. It is the tempting shortcut and it would
+break the property that makes this check worth having: a checkout can be stale,
+shallow, or missing tags entirely (`actions/checkout` fetches none by default),
+and a gate that compares a local list against a remote one is measuring the
+runner, not the repository.
+
+WHAT COUNTS AS A RELEASE. A published one. A DRAFT DOES NOT COUNT, and this is
+the discriminating case: a draft is exactly what an interrupted release leaves
+behind, it is invisible to everyone who is not a maintainer, and it notifies
+nobody. Drafts are filtered explicitly rather than relying on the token's scope
+to hide them, because a token with `contents: write` can see them.
+
+THE FLOOR. Tags below `--floor` are reported and skipped, not silently ignored.
+The release process that requires a release object took effect at v1.10.0 (see
+docs/releasing.md); tags below it predate the policy. A floor is used rather
+than a list of grandfathered tags on purpose -- an exception list never shrinks
+and eventually constrains nothing, whereas a floor is monotone: every tag this
+project will ever cut again is above it.
+
+Usage:
+    python scripts/release_objects_gate.py                    # sweep every tag >= floor
+    python scripts/release_objects_gate.py --tag v1.15.0      # one tag (the tag-push job)
+    python scripts/release_objects_gate.py --tag v1.15.0 --wait-seconds 600
+    python scripts/release_objects_gate.py --floor v1.0.0     # include the pre-policy tags
+
+Exit 0 = every tag in scope has a published release. Exit 1 = at least one does
+not, and each is named. Exit 2 = the check could not run (network, auth, bad
+argument); that is NOT a pass, and it is a distinct code so CI cannot confuse
+"nothing is missing" with "nothing was checked".
+
+Auth is optional for a public repo but strongly preferred: unauthenticated
+GitHub API calls are rate-limited to 60/hour per IP. Reads GH_TOKEN or
+GITHUB_TOKEN from the environment. Requires only `contents: read`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+DEFAULT_REPO = "delphisecurity/xaidr"
+
+# The release cut at which docs/releasing.md's process took effect.
+DEFAULT_FLOOR = "v1.10.0"
+
+# Version tags only. A tag that is not a release tag (a scratch tag, a moved
+# pointer) is not something this gate has an opinion about.
+TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+class CheckError(RuntimeError):
+    """The check could not be run. Distinct from 'the check failed'."""
+
+
+# ── the GitHub side ─────────────────────────────────────────────────────────
+
+
+def _get(path: str, token: str | None):
+    req = urllib.request.Request(
+        f"{API}{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "xaidr-release-objects-gate",
+            **({"Authorization": f"Bearer {token}"} if token else {}),
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:400]
+        raise CheckError(f"GET {path} -> HTTP {exc.code}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise CheckError(f"GET {path} -> {exc.reason}") from exc
+
+
+def _paginate(path: str, token: str | None, cap: int = 20):
+    """Every page, not the first. The default page size is 30; this project
+    already has 15 tags and will pass 30 without anyone noticing, and a gate
+    that silently stops at page one would start passing at exactly the moment
+    it has enough history to matter."""
+    out = []
+    for page in range(1, cap + 1):
+        sep = "&" if "?" in path else "?"
+        chunk = _get(f"{path}{sep}per_page=100&page={page}", token)
+        if not isinstance(chunk, list):
+            raise CheckError(f"GET {path} returned {type(chunk).__name__}, expected a list")
+        out.extend(chunk)
+        if len(chunk) < 100:
+            return out
+    raise CheckError(f"GET {path} exceeded {cap} pages; refusing to report a partial list")
+
+
+def fetch_tags(repo: str, token: str | None) -> list[str]:
+    return [t["name"] for t in _paginate(f"/repos/{repo}/tags", token)]
+
+
+def fetch_published_release_tags(repo: str, token: str | None) -> set[str]:
+    return {
+        r["tag_name"]
+        for r in _paginate(f"/repos/{repo}/releases", token)
+        if not r.get("draft", False)
+    }
+
+
+# ── the comparison, pure so it can be tested without a network ──────────────
+
+
+def version_key(tag: str):
+    m = TAG_RE.match(tag)
+    return tuple(int(p) for p in m.groups()) if m else None
+
+
+def audit(tags, released, floor, only_tag=None):
+    """Return (missing, covered, skipped_below_floor, ignored_non_version).
+
+    `missing` is the finding: version tags in scope with no published release.
+    The other three are returned so the caller can PRINT what it did not check.
+    A gate that reports only its findings reads as full coverage while
+    performing whatever coverage its filters happen to allow.
+    """
+    floor_key = version_key(floor)
+    if floor_key is None:
+        raise CheckError(f"--floor must look like vMAJOR.MINOR.PATCH, got {floor!r}")
+
+    missing, covered, skipped, ignored = [], [], [], []
+    for tag in tags:
+        if only_tag is not None and tag != only_tag:
+            continue
+        key = version_key(tag)
+        if key is None:
+            ignored.append(tag)
+        elif key < floor_key:
+            skipped.append(tag)
+        elif tag in released:
+            covered.append(tag)
+        else:
+            missing.append(tag)
+
+    sort = lambda ts: sorted(ts, key=version_key)  # noqa: E731
+    return sort(missing), sort(covered), sort(skipped), sorted(ignored)
+
+
+# ── reporting ───────────────────────────────────────────────────────────────
+
+
+def run_once(repo, token, floor, only_tag):
+    tags = fetch_tags(repo, token)
+    if only_tag is not None and only_tag not in tags:
+        raise CheckError(
+            f"{only_tag} is not a tag on {repo}. The gate checks the REMOTE tag "
+            f"list, so a tag that exists only locally has not been pushed."
+        )
+    released = fetch_published_release_tags(repo, token)
+    return audit(tags, released, floor, only_tag), len(tags), len(released)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO))
+    ap.add_argument("--floor", default=DEFAULT_FLOOR)
+    ap.add_argument("--tag", default=None, help="check one tag instead of sweeping all")
+    ap.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=0,
+        help=(
+            "poll until the release appears, then pass. For the tag-push job: the "
+            "tag lands a moment before the release object does, and this is the "
+            "grace, not a retry-until-green loop -- it gives up and fails."
+        ),
+    )
+    ap.add_argument("--poll-interval", type=int, default=30)
+    args = ap.parse_args(argv)
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+    print(f"repo   : {args.repo}   (tags and releases both read from {API})")
+    print(f"floor  : {args.floor}")
+    print(f"scope  : {args.tag or 'every version tag at or above the floor'}")
+    print(f"auth   : {'token' if token else 'ANONYMOUS (60 req/hour)'}")
+    print()
+
+    deadline = time.monotonic() + max(0, args.wait_seconds)
+    while True:
+        try:
+            (missing, covered, skipped, ignored), n_tags, n_rel = run_once(
+                args.repo, token, args.floor, args.tag
+            )
+        except CheckError as exc:
+            print(f"CHECK DID NOT RUN: {exc}", file=sys.stderr)
+            print("This is not a pass.", file=sys.stderr)
+            return 2
+
+        if not missing or time.monotonic() >= deadline:
+            break
+        left = int(deadline - time.monotonic())
+        print(f"  {', '.join(missing)} not published yet; {left}s of grace left")
+        time.sleep(min(args.poll_interval, max(1, left)))
+
+    print(f"{n_tags} tags and {n_rel} published releases on the remote.")
+    print(f"  covered : {len(covered)}  {' '.join(covered) if covered else '-'}")
+    if skipped:
+        print(f"  skipped : {len(skipped)} below the {args.floor} floor, NOT checked  "
+              f"{' '.join(skipped)}")
+    if ignored:
+        print(f"  ignored : {len(ignored)} tags that are not vMAJOR.MINOR.PATCH  "
+              f"{' '.join(ignored)}")
+    print()
+
+    if missing:
+        print(f"FAIL: {len(missing)} tag(s) with no published release object.")
+        for tag in missing:
+            print(f"  {tag}  https://github.com/{args.repo}/releases/new?tag={tag}")
+        print()
+        print("A tag is not a release. The notes for these versions exist only in")
+        print("the release commit body, where nobody watching the repo will see")
+        print("them. See docs/releasing.md step 4.")
+        return 1
+
+    if not covered:
+        # An empty in-scope set is the vacuous pass this repo keeps producing.
+        # Say so rather than printing OK over a set of size zero.
+        print("FAIL: nothing was in scope, so nothing was checked.")
+        print(f"  No version tag at or above {args.floor} exists on {args.repo}.")
+        return 1
+
+    print(f"OK: all {len(covered)} version tag(s) at or above {args.floor} "
+          f"have a published release object.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_objects_gate.py
+++ b/tests/test_release_objects_gate.py
@@ -1,0 +1,154 @@
+"""The release-objects gate: does it actually discriminate?
+
+WHY THIS FILE EXISTS. The gate it tests is the fix for a state this repository
+was genuinely in -- fifteen tags, zero release objects, and a green CI run the
+whole time, because nothing in CI could see server-side state. A guard written
+for that failure is itself a running system whose output is a verdict about
+other systems, and this repo's recent history is mostly guards that passed
+while constraining nothing: one that compared a constant to a constant, one
+that always refused, one that passed vacuously on an empty set.
+
+So the cases below are chosen to be the ones that FAIL a decorative
+implementation, not the ones that pass an obvious one:
+
+  * a DRAFT release must not count      -- a draft is what an interrupted
+                                           release leaves behind, and it
+                                           notifies nobody
+  * an empty in-scope set must FAIL     -- the vacuous pass, spelled out
+  * the floor must SKIP, not silently
+    drop                                -- so the report cannot read as full
+                                           coverage over a filtered set
+
+`audit()` is pure -- it takes the two lists rather than fetching them -- so
+every case here runs with no network. The network half is not testable in
+pytest by construction, and is verified by running the script against the live
+API; see docs/releasing.md.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "release_objects_gate",
+    pathlib.Path(__file__).resolve().parents[1] / "scripts" / "release_objects_gate.py",
+)
+gate = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(gate)
+
+
+def test_a_tag_with_a_published_release_is_covered():
+    missing, covered, skipped, ignored = gate.audit(
+        ["v1.10.0"], {"v1.10.0"}, floor="v1.10.0"
+    )
+    assert (missing, covered, skipped, ignored) == ([], ["v1.10.0"], [], [])
+
+
+def test_a_tag_with_no_release_is_the_finding():
+    missing, covered, _, _ = gate.audit(
+        ["v1.10.0", "v1.11.0"], {"v1.10.0"}, floor="v1.10.0"
+    )
+    assert missing == ["v1.11.0"]
+    assert covered == ["v1.10.0"]
+
+
+def test_a_draft_release_does_not_count_as_cut(monkeypatch):
+    """The discriminating case, tested through the FILTER rather than around it.
+
+    Passing a pre-filtered set to `audit()` would prove nothing about drafts --
+    it would just re-test "a tag with no release". So this drives
+    `fetch_published_release_tags` with a payload shaped like the API's, one
+    published and one draft, and asserts the draft's tag does not come back.
+
+    An implementation that took every release object would report a drafted
+    release as cut, and a maintainer interrupted between `--draft` and
+    publishing would be told the release shipped when nobody can see it.
+    """
+    payload = [
+        {"tag_name": "v1.15.0", "draft": False},
+        {"tag_name": "v1.14.0", "draft": True},
+        {"tag_name": "v1.13.0"},  # key absent entirely: the API omits it sometimes
+    ]
+    monkeypatch.setattr(gate, "_paginate", lambda *a, **k: payload)
+
+    published = gate.fetch_published_release_tags("o/r", None)
+    assert published == {"v1.15.0", "v1.13.0"}
+
+    missing, covered, _, _ = gate.audit(
+        ["v1.13.0", "v1.14.0", "v1.15.0"], published, floor="v1.10.0"
+    )
+    assert missing == ["v1.14.0"]
+    assert covered == ["v1.13.0", "v1.15.0"]
+
+
+def test_tags_below_the_floor_are_skipped_and_reported_not_dropped():
+    missing, covered, skipped, _ = gate.audit(
+        ["v1.9.0", "v1.10.0"], {"v1.10.0"}, floor="v1.10.0"
+    )
+    assert missing == []
+    assert covered == ["v1.10.0"]
+    # v1.9.0 genuinely has no release object. The gate does not fail on it, but
+    # it MUST hand it back so the caller prints it. A filter that returned only
+    # `missing` would print "OK" over a repository with six uncut releases.
+    assert skipped == ["v1.9.0"]
+
+
+def test_a_non_version_tag_is_ignored_and_reported():
+    missing, _, _, ignored = gate.audit(
+        ["scratch", "v1.10.0"], {"v1.10.0"}, floor="v1.10.0"
+    )
+    assert missing == []
+    assert ignored == ["scratch"]
+
+
+def test_ordering_is_by_version_not_lexical():
+    """`sorted()` on strings puts v1.9.0 after v1.10.0. The report is read by a
+    human deciding which release to cut first, and a list that claims 1.9 is
+    newer than 1.10 is a list they have to re-sort in their head."""
+    missing, _, _, _ = gate.audit(
+        ["v1.9.0", "v1.10.0", "v1.11.0"], set(), floor="v1.0.0"
+    )
+    assert missing == ["v1.9.0", "v1.10.0", "v1.11.0"]
+
+
+def test_a_bad_floor_is_an_error_not_a_pass():
+    with pytest.raises(gate.CheckError):
+        gate.audit(["v1.10.0"], set(), floor="1.10")
+
+
+def test_single_tag_scope_ignores_every_other_tag():
+    missing, covered, _, _ = gate.audit(
+        ["v1.10.0", "v1.11.0"], {"v1.11.0"}, floor="v1.10.0", only_tag="v1.11.0"
+    )
+    assert missing == []
+    assert covered == ["v1.11.0"]
+
+
+def test_empty_scope_is_reported_as_no_coverage(capsys, monkeypatch):
+    """The vacuous pass, pinned at the exit-code level.
+
+    With no tag at or above the floor there is nothing to check, and the
+    tempting implementation returns 0 because `missing` is empty. That is the
+    shape that let a green suite hide seven CANCELLED tests. `main()` must
+    treat an empty covered set as a FAILURE.
+    """
+    monkeypatch.setattr(
+        gate, "run_once", lambda *a, **k: ((([], [], ["v1.9.0"], [])), 1, 0)
+    )
+    rc = gate.main(["--repo", "o/r", "--floor", "v1.10.0"])
+    assert rc == 1
+    assert "nothing was checked" in capsys.readouterr().out
+
+
+def test_a_check_that_could_not_run_exits_2_not_0(capsys, monkeypatch):
+    """Network failure, auth failure and rate-limiting must not look like a
+    pass. Exit 2 is distinct from both 0 and 1 so CI cannot confuse "nothing is
+    missing" with "nothing was checked"."""
+    def boom(*a, **k):
+        raise gate.CheckError("HTTP 403: rate limit exceeded")
+
+    monkeypatch.setattr(gate, "run_once", boom)
+    rc = gate.main(["--repo", "o/r"])
+    assert rc == 2
+    assert "not a pass" in capsys.readouterr().err


### PR DESCRIPTION
This repository had FIFTEEN TAGS AND ZERO RELEASE OBJECTS until 2026-09-09. The
notes for every one of them -- including a webhook credential leak that required
a secret rotation, and a CrewAI boundary 1.6.1 reported as PATCHED while a
destructive tool call executed anyway -- existed only in a release commit body.
CI was green throughout, because nothing in CI could see server-side state.

docs/releasing.md, not CONTRIBUTING.md. CONTRIBUTING opens "thanks for your
interest in contributing" and is addressed to people who cannot do any of this:
cutting a release needs push access to tags and a token. Putting it there sends
every drive-by reader through steps they cannot run, and buries the maintainer
procedure in a document nobody rereads. docs/ already holds the operator-facing
material (rollout, testing, provenance) and does not ship in either artifact,
which is right for a procedure aimed at someone working in the repo rather than
someone arriving from `pip install`. CONTRIBUTING gets a pointer and the two
facts that change what a PR must carry.

FIVE STEPS, ordered so the tag is verified before it is public: reconcile the
notes against `git log <prev>..HEAD` and check every cited SHA is an ancestor;
tag locally; build from a clean clone of the tag and verify from the artifact at
a neutral cwd with `xaidr.__file__` asserted inside site-packages; prove
detection byte-identical against the PUBLISHED previous wheel with every intended
change enumerated; then push and create the release object, minutes apart.

Step 1 is the one that failed at 1.15.0 -- PR #5 merged after the notes were
drafted, so the SensorExtension seam, the monitor-mode field-loss fix and the
per-site fail-open sabotage all shipped undescribed, and one of them changes what
a monitor-mode sensor returns. Step 3's two halves are both load-bearing: run
from the source tree and Python imports ./xaidr/ in preference to the installed
package, and printing __version__ does not catch it because the string is
identical either way.

U-1 -- NO FIGURE WITHOUT A REGENERATOR. Seven distinct hex digests are cited
across six release bodies (v1.9.0, v1.10.0, v1.11.0, v1.12.0, v1.13.0, v1.14.0)
as the proof that detection did not move. Not one has ever appeared in a
committed file, on any branch, at any point in this repository's history --
`git log --all -S<digest> --pickaxe-all` finds nothing for all seven, and no
script computes a corpus verdict digest at all. The strongest evidence those
releases offer cannot be reproduced, disproved, or told apart from a number that
was typed. Withholding a figure with a reason is honest, as heldout/ already
does; quoting an unreproducible one is not. The corpus-digest regenerator is
named as debt rather than assumed to exist.

THE GATE READS THE API, NOT THE TREE. scripts/release_objects_gate.py fetches
BOTH sides -- /repos/{repo}/tags and /repos/{repo}/releases -- and never calls
`git tag`. That is the whole point: ci.yml proves the tree is self-consistent and
stayed green for months over this exact failure, and `actions/checkout` fetches
no tags by default, so a gate comparing a local list to a remote one measures the
runner and passes vacuously. Drafts do not count. Tags below the v1.10.0 floor
are printed as skipped rather than dropped, so the output cannot read as
coverage it did not perform. Exit 2 is "could not run", distinct from 0 and 1.

FAILING-FIRST PROOF. Each discriminating case sabotaged one at a time, restored
between (script byte-identical to pre-sabotage afterwards):

  drafts count as published    -> assert {v1.13.0, v1.14.0, v1.15.0} == {v1.13.0, v1.15.0}
                                  Extra items in the left set: 'v1.14.0'
  empty scope returns OK       -> assert 0 == 1   ("nothing was checked" not raised)
  could-not-run passes         -> assert 0 == 2
  lexical sort not version     -> At index 0 diff: 'v1.10.0' != 'v1.9.0'
  below-floor tags dropped     -> assert [] == ['v1.9.0']

Green after restore: 10 passed.

VERIFIED FROM OUTSIDE, against the live GitHub API, not a fixture:

  --floor v1.0.0   FAIL, exit 1: names v1.5.0 v1.6.0 v1.6.1 v1.7.0 v1.8.0 v1.9.0
                   as the six tags with no published release object
  --floor v1.10.0  OK,   exit 0: all 7 tags at or above the floor covered,
                   8 below-floor tags printed as skipped
  v1.14.0 flipped to draft, shipped floor -> FAIL, exit 1, names v1.14.0.
                   Restored to published; body verified byte-identical after.

The last one is the discriminating case at the SHIPPED floor: the red at
--floor v1.0.0 only proves the gate sees pre-policy tags, and a gate that could
not fail on a tag it actually governs would have passed that test too.

NOT VERIFIED HERE, and deferred rather than skipped: that the workflow FIRES on
a tag push. `workflow_dispatch` needs the workflow on the default branch and no
tag has been pushed since this was written, so both triggers are unexercised.
The YAML parses and resolves to two jobs under `push`/`schedule`/
`workflow_dispatch` with `contents: read`; the trigger itself is settled by the
first `v*` push after this merges, and that run is the check to read.

Signed-off-by: Anirudh Kotaru <anirudh@delphisecurity.ai>
