### PR TITLE
feat(egress): consolidated outbound headers with flag-gated provenance (seam S12)

### DIFF
--- a/docs/enterprise-seams-design.md
+++ b/docs/enterprise-seams-design.md
@@ -1,6 +1,6 @@
 # Enterprise seams for open `xaidr` — design against `864243e`
 
-**Status:** S7 built (PR 1); S1 + S5 + S6 built (PR 2); S2 built (PR 3, completed in PR 5); S3 built (PR 4); S9 + S10 + S11 built (PR 5). S4, S8, S12, S13 still design. Base: `delphisecurity/xaidr` main at `864243e` (release 1.11.0); the seam line numbers in §2 are on that commit and have since shifted — read them as "which function", not "which line". PR #3 (ASI/LPCI rules) shifts `local.py` by +34 lines and touches no seam site.
+**Status:** S7 built (PR 1); S1 + S5 + S6 built (PR 2); S2 built (PR 3, completed in PR 5); S3 built (PR 4); S9 + S10 + S11 built (PR 5); S12 built flag-gated (PR 6, extension header merging still design). S4, S8, S13 still design. Base: `delphisecurity/xaidr` main at `864243e` (release 1.11.0); the seam line numbers in §2 are on that commit and have since shifted — read them as "which function", not "which line". PR #3 (ASI/LPCI rules) shifts `local.py` by +34 lines and touches no seam site.
 **Companion:** `docs/enterprise-overlay-spec.md` (the bucket classification, currently sitting in `~/delphi-sentinel/docs/`, to be moved to the SDK repo). This document replaces its §5 hook table.
 **Goal:** paid = pinned open `xaidr` + an enterprise package. Every behaviour paid has today that open lacks must plug into open through a public, tested, validated-at-construction seam, so that the next open release cannot silently break the enterprise package and the next enterprise feature cannot fork a shared file.
 
@@ -165,11 +165,22 @@ Before the operator blocklist check (`:2434`), each extension's `destination_pol
 
 The reader at `:2435` holds `self._sensor._blocked_urls`, and `unblock_urls` rebinds the list at `:1692`, so any provider that caches a reference goes stale. Design: `_effective_blocked_urls()` computed at read time as `self._blocked_urls + [u for ext in extensions for u in (ext.blocked_urls() or ())]`, called at `:2435` on every check. No refresh hook is needed; a provider that wants freshness returns a fresh sequence each call and rate-limits itself. Test: register a provider whose list changes between two calls and assert the second call sees the change. Also tested: `unblock_urls` composed with a provider — the operator's removal takes effect while the extension's contribution survives the rebind, which is exactly the staleness a cached reference produces. An operator cannot `unblock_urls` an extension's entry; that list is the extension's, and letting the operator delete from it would make the enterprise control removable by the thing it constrains.
 
-### S12 · outbound headers — five egress verbs (`sensor.py:2579`, `:2588`, `:2597`; none on `:2603`, `:2612`; was H14)
+### S12 · outbound headers — five egress verbs (was H14), BUILT (flag-gated)
 
-Consolidate: one `_egress_headers(dest) -> dict` used by all five verbs (GET and DELETE currently write no headers at all). It writes `X-Delphi-Source-Agent`, then **calls `provenance_chain.inject_context`** (`provenance_chain.py:355`, exported, and never called from the sensor's own egress today), then merges `ext.outbound_headers(dest)` from each extension. Extensions may add headers, never remove or overwrite an open one (collision raises at call time, once, then the extension's header is dropped).
+One `_egress_headers(dest, headers, *, source_agent) -> dict` used by all five verbs: `post` (`sensor.py:3424`), `put` (`:3433`), `patch` (`:3442`), `get` (`:3451`), `delete` (`:3460`). Before this seam the three body verbs wrote `X-Delphi-Source-Agent` and GET/DELETE wrote no header at all.
 
-Wiring `inject_context` is an open behaviour change in its own right and gets its own commit and test (a GET through `protect_http` carries `x-openA2A-chain`). It closes the "writer exists, unwired" gap on the open side; the paid "reader with no writer" gap then closes by inheritance.
+**Gated by `Sensor(emit_provenance_headers=False)`, default OFF.** The flag is what makes this seam SATISFY non-negotiable #1 rather than override it. An earlier draft of this section framed the `inject_context` wiring as "an open behaviour change in its own right" — that framing is withdrawn, because with a default-off flag the default behaviour does not change at all.
+
+* **Flag off:** byte-identical to the tree before this seam. Body verbs send exactly `X-Delphi-Source-Agent`; GET and DELETE send nothing. The asymmetry is preserved deliberately — GET/DELETE starting to announce the agent id to hosts that never received it is a DISCLOSURE change, and consolidating call sites is not a licence to make one.
+* **Flag on:** every verb carries `X-Delphi-Source-Agent` plus the four headers `provenance_chain.inject_context` (`provenance_chain.py:387`) writes — `traceparent`, `x-openA2A-correlation`, `x-openA2A-chain`, `x-openA2A-tiers`. GET and DELETE are included on purpose: a deployer who asked for the chain to be visible should not find a GET-shaped hole in it.
+
+**The disclosure is the reason for the default.** With the flag on, every destination a protected client talks to receives this agent's id, a correlation id and the delegation chain. That is not the SDK's call to make on a deployer's behalf, so it is opt-in — the same reasoning as `enable_nano` refusing to fetch a 130 MB artifact as a side effect of construction.
+
+**The corpus oracle is blind to this seam**, and that is the interesting part. It hashes `scan()` verdicts over the committed corpus; it makes no HTTP request and inspects no header, so S12 could change what every outbound call discloses and the oracle would stay byte-identical. `tests/test_egress_headers.py` is the real zero-movement gate here, and it says so in its own docstring. A seam whose gate cannot see it needs a new gate, not a green run from the old one.
+
+The `inject_context` claim in the earlier draft was verified rather than assumed: nothing in `xaidr/` called it. Only `__init__.py` (the export), four tests, and the user-facing docs did. The "writer exists, unwired" gap is now closed on the open side whenever the flag is on.
+
+**Still design, NOT built here:** merging `ext.outbound_headers(dest)` from each extension, with the collision rule (extensions may add headers, never remove or overwrite an open one). The helper is the seam that will host it; this PR wired the consolidation and the flag only.
 
 ### S13 · tools declared — `Sensor.protect_tools` (`sensor.py:1956`, was H15)
 
@@ -223,7 +234,7 @@ Contract violations share a base, `_ExtensionContractError`, and every scan entr
 3. **S2** policy conditions through `parse_action_policy`. BUILT.
 4. **S3** escalation chain in `LocalScanner`, flag-band cap, degraded signal, manifest health. BUILT.
 5. **S9 + S10 + S11** trust, destination policy, blocked-URL provider. BUILT.
-6. **S12** egress header consolidation, with `inject_context` wiring as its own commit.
+6. **S12** egress header consolidation, with `inject_context` wiring behind a default-off flag. BUILT (extension `outbound_headers` merging still design).
 7. **S4 + S8 + S13** before_scan, on_response, tools declared.
 
 Then release open (1.12.0), pin it, and build the enterprise package: `BrainReporter`, the quarantine gate, `watch` policy, `trust_below` condition, AGT destination policy, the Brain escalator, identity/context modules. The parity guard flips to "enterprise ⊇ open" and stays green by construction.

--- a/tests/test_egress_headers.py
+++ b/tests/test_egress_headers.py
@@ -1,0 +1,197 @@
+"""S12 · outbound egress headers, and the flag that gates provenance.
+
+THIS FILE IS THE ZERO-MOVEMENT GATE FOR THIS SEAM, and it has to be, because
+the corpus oracle cannot see it. The oracle hashes `scan()` verdicts — action,
+score, category, rules — over the committed corpus. It does not make an HTTP
+request and it never inspects a header, so S12 could change what every outbound
+call discloses to every destination host and the oracle would stay byte-identical
+at the same sha256 it has had for four PRs. A green oracle here would mean
+"nothing this gate can see moved", which is not the same sentence as "nothing
+moved".
+
+So the flag-off half below is not a nicety. It is the only thing standing between
+"consolidated five call sites into one" and "silently started announcing the
+agent id, a correlation id and the delegation chain to every host this process
+talks to".
+
+THE ASYMMETRY IS DELIBERATE. Before this seam, POST/PUT/PATCH wrote
+`X-Delphi-Source-Agent` and GET/DELETE wrote no header at all. With the flag off
+that is preserved exactly — GET and DELETE still send nothing. Making them start
+sending the agent id would be a disclosure change, and it is the same change the
+flag exists to gate; consolidating call sites is not a licence to make it.
+With the flag ON every verb carries the full set, because a deployer who asked
+for the chain to be visible should not find a GET-shaped hole in it.
+"""
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+from xaidr import Sensor, begin_flow, clear_flow                 # noqa: E402
+
+VERBS = ("post", "put", "patch", "get", "delete")
+BODY_VERBS = ("post", "put", "patch")
+BARE_VERBS = ("get", "delete")
+
+SOURCE_AGENT = "X-Delphi-Source-Agent"
+#: Exactly what `provenance_chain.inject_context` writes. Spelled out rather
+#: than imported so that a change to the writer has to be acknowledged here.
+PROVENANCE_HEADERS = frozenset({
+    "traceparent",
+    "x-openA2A-correlation",
+    "x-openA2A-chain",
+    "x-openA2A-tiers",
+})
+
+
+class _Capture:
+    """Replaces the underlying httpx verbs and records the headers sent."""
+
+    def __init__(self):
+        self.seen = {}
+
+    def bind(self, client):
+        for verb in VERBS:
+            setattr(client._client, verb, self._recorder(verb))
+        return client
+
+    def _recorder(self, verb):
+        def call(url, **kwargs):
+            self.seen[verb] = dict(kwargs.get("headers") or {})
+            return httpx.Response(
+                200, request=httpx.Request(verb.upper(), url))
+        return call
+
+
+def _drive(emit, *, caller_headers=None, with_flow=True):
+    sensor = Sensor(agent_id="egress-test", emit_provenance_headers=emit)
+    client = sensor.protect_http(httpx.Client())
+    cap = _Capture()
+    cap.bind(client)
+    clear_flow()
+    if with_flow:
+        begin_flow(principal="alice")
+    extra = {"headers": caller_headers} if caller_headers else {}
+    client.post("https://h.example/x", json={}, **extra)
+    client.put("https://h.example/x", json={}, **extra)
+    client.patch("https://h.example/x", json={}, **extra)
+    client.get("https://h.example/x", **extra)
+    client.delete("https://h.example/x", **extra)
+    clear_flow()
+    return cap.seen
+
+
+# ── flag OFF: byte-identical to the tree before this seam ────────────────────
+
+def test_off_body_verbs_send_only_the_source_agent():
+    seen = _drive(False)
+    for verb in BODY_VERBS:
+        assert set(seen[verb]) == {SOURCE_AGENT}, (
+            f"{verb} sent {sorted(seen[verb])}; before S12 it sent exactly "
+            f"{SOURCE_AGENT}"
+        )
+        assert seen[verb][SOURCE_AGENT] == "egress-test"
+
+
+def test_off_get_and_delete_send_NO_headers():
+    """The half that would break first if consolidation leaked a disclosure.
+
+    GET and DELETE wrote no header at all before this seam. Them starting to
+    announce the agent id is exactly the unrequested disclosure the flag gates.
+    """
+    seen = _drive(False)
+    for verb in BARE_VERBS:
+        assert seen[verb] == {}, (
+            f"{verb} sent {sorted(seen[verb])} with the provenance flag OFF; "
+            "before S12 it sent nothing at all"
+        )
+
+
+def test_off_no_provenance_header_appears_on_any_verb():
+    seen = _drive(False)
+    for verb in VERBS:
+        leaked = PROVENANCE_HEADERS & {k.lower() for k in seen[verb]} | (
+            PROVENANCE_HEADERS & set(seen[verb]))
+        assert not leaked, f"{verb} leaked provenance headers {sorted(leaked)}"
+
+
+def test_off_is_the_default():
+    """Nobody opts out; the disclosure is opt-IN."""
+    assert Sensor(agent_id="default-probe").emit_provenance_headers is False
+
+
+def test_off_preserves_caller_supplied_headers():
+    seen = _drive(False, caller_headers={"X-Caller": "mine"})
+    for verb in VERBS:
+        assert seen[verb].get("X-Caller") == "mine"
+
+
+# ── flag ON: every verb carries the full set ─────────────────────────────────
+
+def test_on_every_verb_carries_source_agent_and_all_four_provenance_headers():
+    seen = _drive(True)
+    for verb in VERBS:
+        sent = set(seen[verb])
+        assert SOURCE_AGENT in sent, f"{verb} lost {SOURCE_AGENT}"
+        missing = PROVENANCE_HEADERS - sent
+        assert not missing, f"{verb} is missing {sorted(missing)}"
+
+
+def test_on_get_and_delete_are_not_a_hole_in_the_chain():
+    """The specific regression the consolidation exists to prevent: a deployer
+    who turned the chain on must not find two verbs quietly omitting it."""
+    seen = _drive(True)
+    for verb in BARE_VERBS:
+        assert PROVENANCE_HEADERS <= set(seen[verb])
+
+
+def test_on_the_chain_header_carries_the_flow():
+    seen = _drive(True)
+    corr = {seen[v]["x-openA2A-correlation"] for v in VERBS}
+    assert all(c for c in corr), "correlation id must be populated"
+    assert seen["get"]["traceparent"].startswith("00-")
+
+
+def test_on_preserves_caller_supplied_headers():
+    seen = _drive(True, caller_headers={"X-Caller": "mine"})
+    for verb in VERBS:
+        assert seen[verb].get("X-Caller") == "mine"
+
+
+def test_on_does_not_change_the_source_agent_value():
+    seen = _drive(True)
+    for verb in VERBS:
+        assert seen[verb][SOURCE_AGENT] == "egress-test"
+
+
+# ── the consolidation itself ─────────────────────────────────────────────────
+
+def test_all_five_verbs_route_through_one_helper():
+    """S12's grep tripwire, as a test. Five call sites that can drift are what
+    this seam exists to remove; asserting the source keeps the claim honest
+    even if a future verb is added without one."""
+    import inspect
+
+    from xaidr.sensor import ProtectedHttpClient
+
+    for verb in VERBS:
+        src = inspect.getsource(getattr(ProtectedHttpClient, verb))
+        assert "_egress_headers(" in src, (
+            f"{verb} does not route through _egress_headers — S12's whole "
+            "claim is that there is exactly one place a header is written"
+        )
+
+
+def test_no_verb_writes_the_source_agent_header_directly():
+    """The other half of the tripwire: consolidation is only real if the old
+    direct writes are gone."""
+    import inspect
+
+    from xaidr.sensor import ProtectedHttpClient
+
+    for verb in VERBS:
+        src = inspect.getsource(getattr(ProtectedHttpClient, verb))
+        assert SOURCE_AGENT not in src, (
+            f"{verb} still writes {SOURCE_AGENT} directly instead of going "
+            "through the helper"
+        )

--- a/xaidr/sensor.py
+++ b/xaidr/sensor.py
@@ -461,6 +461,7 @@ class DelphiSensor:
         circuit_breaker: Optional[CircuitBreaker] = None,
         privilege_tier: int | None = None,
         extensions: Sequence[SensorExtension] = (),
+        emit_provenance_headers: bool = False,
     ):
         if not agent_id:
             raise ValueError("agent_id is required")
@@ -495,6 +496,21 @@ class DelphiSensor:
         self._declared_tier = self.privilege_tier if privilege_tier is not None else None
 
         self.agent_id = agent_id
+        # S12 · emit delegation provenance on outbound `protect_http` calls.
+        #
+        # DEFAULT OFF, and the default is the point. Turning this on sends this
+        # agent's id, a correlation id and the whole delegation chain to every
+        # destination a protected client talks to — hosts that receive none of
+        # it today. That is a DISCLOSURE change, not merely an internal one, and
+        # it is not ours to make on a deployer's behalf. Opting in is a
+        # deliberate act, exactly like `enable_nano` above reaching for a 130 MB
+        # artifact rather than fetching it as a side effect of construction.
+        #
+        # With it off, every egress verb emits byte-identical headers to what it
+        # emitted before this seam existed — which is what keeps non-negotiable
+        # #1 satisfied here rather than overridden. `tests/test_egress_headers.py`
+        # is the gate for that, because the corpus oracle cannot see headers.
+        self.emit_provenance_headers = emit_provenance_headers
         self.shadow_mode = shadow_mode
         # shadow_mode forces observe-only — it IS monitor mode.
         self.enforcement = _MONITOR if shadow_mode else enforcement
@@ -3421,29 +3437,54 @@ class ProtectedHttpClient:
                 raise DelphiBlockedError(result)
         return response
 
+    def _egress_headers(self, dest, headers=None, *, source_agent: bool) -> dict:
+        """S12 · the ONE place an outbound header is written. All five verbs
+        call it, so "what does xaidr add to an outbound request" has a single
+        answer rather than five that can drift.
+
+        ``source_agent`` records which verbs wrote ``X-Delphi-Source-Agent``
+        BEFORE this seam existed: the body verbs always did, GET and DELETE
+        never wrote any header at all. Consolidating the call sites must not
+        silently change what leaves the process, so with the provenance flag OFF
+        that asymmetry is preserved exactly. It is a DISCLOSURE, and GET/DELETE
+        starting to announce the agent id to hosts that never received it would
+        be the same unrequested change the flag exists to gate.
+
+        With the flag ON every verb writes the source agent and the four
+        provenance headers, because at that point the deployer has asked for the
+        chain to be visible and a GET that omitted it would be a hole in it.
+
+        Caller-supplied headers are preserved; ``inject_context`` merges into
+        the dict it is given rather than replacing it.
+        """
+        out = dict(headers or {})
+        emit = self._sensor.emit_provenance_headers
+        if source_agent or emit:
+            out['X-Delphi-Source-Agent'] = self._sensor.agent_id
+        if emit:
+            # The writer has existed and been exported since provenance landed;
+            # nothing in the sensor's own egress ever called it. This is that
+            # wiring, behind the flag.
+            out = _chain.inject_context(out)
+        return out
+
     def post(self, url, *, json=None, content=None, headers=None, **kwargs):
         """POST with A2A scanning."""
-        headers = dict(headers or {})
-        headers['X-Delphi-Source-Agent'] = self._sensor.agent_id
-
+        headers = self._egress_headers(url, headers, source_agent=True)
         self._scan_request(str(url), json, content)
         response = self._client.post(url, json=json, content=content, headers=headers, **kwargs)
         return self._scan_response(response)
 
     def put(self, url, *, json=None, content=None, headers=None, **kwargs):
         """PUT with A2A scanning."""
-        headers = dict(headers or {})
-        headers['X-Delphi-Source-Agent'] = self._sensor.agent_id
-
+        headers = self._egress_headers(url, headers, source_agent=True)
         self._scan_request(str(url), json, content)
         response = self._client.put(url, json=json, content=content, headers=headers, **kwargs)
         return self._scan_response(response)
 
     def patch(self, url, *, json=None, content=None, headers=None, **kwargs):
         """PATCH with A2A scanning."""
-        headers = dict(headers or {})
-        headers['X-Delphi-Source-Agent'] = self._sensor.agent_id
-
+        headers = self._egress_headers(url, headers, source_agent=True)
         self._scan_request(str(url), json, content)
         response = self._client.patch(url, json=json, content=content, headers=headers, **kwargs)
         return self._scan_response(response)
@@ -3455,6 +3496,10 @@ class ProtectedHttpClient:
         to a denied destination is blocked before the request leaves the host.
         """
         self._check_destination(str(url), None)
+        headers = self._egress_headers(url, kwargs.pop("headers", None),
+                                       source_agent=False)
+        if headers:
+            kwargs["headers"] = headers
         return self._client.get(url, **kwargs)
 
     def delete(self, url, **kwargs):
@@ -3464,6 +3509,10 @@ class ProtectedHttpClient:
         is blocked before it is sent.
         """
         self._check_destination(str(url), None)
+        headers = self._egress_headers(url, kwargs.pop("headers", None),
+                                       source_agent=False)
+        if headers:
+            kwargs["headers"] = headers
         return self._client.delete(url, **kwargs)
 
     def close(self):


### PR DESCRIPTION
PR 6 of the enterprise-seam sequencing (S7 → #4, S1+S5+S6 → #5, S2 → #6, S3 → #8, S9+S10+S11 → #9).

## Default behaviour is unchanged. Here is the tradeoff, without reading the diff.

**Off by default.** `Sensor(emit_provenance_headers=False)` is the default, and with it off every egress verb emits byte-identical headers to `main` today.

**What turns it on:** `Sensor(agent_id=..., emit_provenance_headers=True)`. Nothing else — no env var, no policy, no extension.

**The disclosure consequence when you turn it on:** every destination host a `protect_http` client talks to begins receiving

- `X-Delphi-Source-Agent` — this agent's id
- `x-openA2A-correlation` — a correlation id linking calls across the flow
- `x-openA2A-chain` — the **full delegation chain** (`id:role>id:role>…`)
- `x-openA2A-tiers` — privilege tiers, positionally aligned to that chain
- `traceparent` — W3C trace context

Hosts that receive **none** of this today will receive all of it. That is a disclosure change to third parties, which is why it is opt-in rather than a consolidation side effect — the same reasoning as `enable_nano` refusing to fetch a 130 MB artifact as a side effect of construction.

## The matrix

| verb | flag OFF | flag ON |
|---|---|---|
| `post` / `put` / `patch` | `X-Delphi-Source-Agent` only | source agent + all four provenance headers |
| `get` / `delete` | **nothing** | source agent + all four provenance headers |

## One deliberate departure from the instruction as written

The brief said `_egress_headers` writes `X-Delphi-Source-Agent` **unconditionally**, and that GET/DELETE "gain the same treatment as the other three". Taken literally that contradicts the next requirement — "flag off → all five verbs produce byte-identical headers to current main" — because on `main` GET and DELETE write **no header at all**. Unconditional would have them start announcing the agent id to hosts that never received it, with the flag off.

Resolved in favour of the byte-identical requirement: `source_agent=` records which verbs wrote the header before this seam (body verbs yes, GET/DELETE no), and with the flag **on** all five carry everything. Flagging it because it is a judgement call on a disclosure question, not a detail.

## Non-negotiable #1: satisfied, not overridden

Section 0 is **untouched**. The preflight flagged this seam as needing an override; with a default-off flag it does not — default behaviour does not change. The S12 section's earlier "an open behaviour change in its own right" framing is withdrawn in this PR, because it described a default-on design that is not what shipped.

## The corpus oracle is blind to this seam

It hashes `scan()` verdicts over the committed corpus. It makes no HTTP request and inspects no header, so S12 could change what every outbound call discloses and the oracle would stay byte-identical at `80f31ff0…` — as it does below. **A green oracle here means "nothing this gate can see moved", which is not "nothing moved".**

`tests/test_egress_headers.py` is the real zero-movement gate for this seam and says so in its own docstring. A seam the existing gate cannot see needs a new gate, not a green run from the old one.

## Counts

```
corpus oracle  clean base 946ecbb : 456 rows sha256=80f31ff0b5d5f107...f10a1bb8
               this branch        : 456 rows sha256=80f31ff0b5d5f107...f10a1bb8   identical
               (identical BY CONSTRUCTION — see above; not evidence for this seam)

full suite     clean base 946ecbb : 8064 passed / 137 skipped / 3 xfailed
               this branch        : 8076 passed / 137 skipped / 3 xfailed
               +12 = exactly the new egress tests
```

## Failing-first — both directions

```
flag ON,  inject_context call site broken   -> 3 failed
flag OFF, emit guard removed                -> 3 failed
flag OFF, source_agent guard removed        -> 1 failed  (GET/DELETE leak the agent id)
default flipped to True                     -> 1 failed
```

The two **flag-off** sabotages are the ones that matter: they prove the off-guards are load-bearing rather than decorative, which is the half a flag-gated seam is easiest to get wrong. Restored: `12 passed`.

Two tripwires shipped as tests rather than greps — every verb routes through `_egress_headers`, and no verb writes the source-agent header directly. Consolidation is only real if the old direct writes are gone.

## Census corrections folded into the doc

| Doc S12 said | Tree has |
|---|---|
| verbs at `:2579`, `:2588`, `:2597`, `:2603`, `:2612` | **`:3424`, `:3433`, `:3442`, `:3451`, `:3460`** |
| `inject_context` at `provenance_chain.py:355` | **`:387`** |
| "never called from the sensor's own egress today" | **verified true** — only `__init__.py`'s export, four tests, and user docs call it |

Also checked and worth stating: **no test asserted the absence of chain headers on egress**, so nothing had to be updated to avoid a false failure. The three `protect_http` test files assert on headers not at all — not even the existing `X-Delphi-Source-Agent`. Egress headers were entirely unpinned in either direction before this PR.

## Still design, not built here

Merging `ext.outbound_headers(dest)` from each extension, with the collision rule (extensions may add, never remove or overwrite an open header). `_egress_headers` is the seam that will host it; this PR wired the consolidation and the flag only. The doc records that explicitly rather than marking S12 done.
