### PR TITLE
fix(logging): stop sensor-owned sinks copying third-party exception text

### DIFF
--- a/tests/test_audit_sep09_f8_extension_fault_leak.py
+++ b/tests/test_audit_sep09_f8_extension_fault_leak.py
@@ -1,0 +1,374 @@
+"""F8 (Sept 9 audit): a scanned prompt must not reach the logs via an
+extension's own exception.
+
+REPRODUCED ON 1.16.0 before any of this was written. A `SensorExtension` whose
+`gate()` raised with the scan text in the message put that text on the sensor's
+own ERROR line, verbatim and in full:
+
+    xaidr: extension 'acme-quarantine' raised in gate() (ValueError: quarantine
+    lookup failed for input 'please summarise this internal memo:
+    PRIVATE_PROMPT_CANARY do not disclose'). THIS CONTROL IS INERT until ...
+
+Four hooks reached that one sink and every one of them leaked: `gate`,
+`transform_verdict`, `subject_trust`, `blocked_urls`. `escalation.run_escalators`
+had the identical shape in its own file.
+
+THE EXTENSION IS ENTITLED TO THE PROMPT. That is what `ScanRequest.text` is for.
+The sensor's LOG is not, and `_extension_failed` shipped without the treatment
+`_emit_scan_error` had had all along on the scan path four screens away.
+
+WHY `safe_exc` IS NOT THE FIX, and why this file asserts that directly below.
+`safe_exc` redacts URLs out of a message it otherwise keeps — right for a
+reporter that failed against a destination, where the destination has a grammar
+and is the diagnostic. An extension's exception text is arbitrary caller prose
+with no grammar; there is no pattern separating the prompt from the diagnostic.
+`test_safe_exc_would_NOT_have_fixed_this` is the discriminating case: it pins
+that the tool the other paths use passes this canary through untouched.
+
+The COUNT is the assertion, as in `test_audit_f8_reporter_redaction.py`: every
+test asserts ZERO occurrences across logging, stdout and stderr — and, in the
+same breath, that the line is still USABLE (names the extension, the hook and
+the exception type). A sink made safe by going silent is not a fix.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+
+import pytest
+
+from xaidr import Sensor
+from xaidr.escalation import Escalator, run_escalators
+from xaidr.extensions import ScanRequest, SensorExtension
+from xaidr.reporters import exc_origin, safe_exc, safe_fault
+from xaidr.types import ScanResult
+
+CANARY = "PRIVATE_PROMPT_CANARY"
+PROMPT = f"please summarise this internal memo: {CANARY} do not disclose"
+
+
+class _NullReporter:
+    """No telemetry sink at all — so anything captured came from a LOG."""
+
+    def report(self, *a, **k): ...
+    def close(self, *a, **k): ...
+
+
+class _Capture:
+    """Everything a fault could write: the xaidr loggers, stdout, stderr.
+
+    The handler is attached to the ``xaidr`` PARENT logger, so a sink added in
+    any submodule is captured without this file having to know its name — which
+    is the whole point of a regression test for "one path was added without the
+    treatment the others had".
+    """
+
+    def __enter__(self):
+        self.buf = io.StringIO()
+        self._handler = logging.StreamHandler(self.buf)
+        self._handler.setLevel(logging.DEBUG)
+        self._logger = logging.getLogger("xaidr")
+        self._level = self._logger.level
+        self._propagate = self._logger.propagate
+        self._logger.addHandler(self._handler)
+        self._logger.setLevel(logging.DEBUG)
+        self._out, self._err = sys.stdout, sys.stderr
+        self._so, self._se = io.StringIO(), io.StringIO()
+        sys.stdout, sys.stderr = self._so, self._se
+        return self
+
+    def __exit__(self, *exc):
+        sys.stdout, sys.stderr = self._out, self._err
+        self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._level)
+        self._logger.propagate = self._propagate
+        return False
+
+    @property
+    def text(self) -> str:
+        return self.buf.getvalue() + self._so.getvalue() + self._se.getvalue()
+
+    def counts(self) -> dict:
+        return {
+            "logging": self.buf.getvalue().count(CANARY),
+            "stdout": self._so.getvalue().count(CANARY),
+            "stderr": self._se.getvalue().count(CANARY),
+        }
+
+    def assert_clean(self, what: str):
+        c = self.counts()
+        total = sum(c.values())
+        assert total == 0, (
+            f"{what}: the scanned prompt leaked. The canary appears {total} "
+            f"time(s) in sensor-owned output "
+            f"(logging={c['logging']} stdout={c['stdout']} stderr={c['stderr']}"
+            ").\n--- captured ---\n" + self.text + "\n---"
+        )
+
+    def assert_still_useful(self, *needles: str):
+        """A sink made safe by saying nothing is not a fix."""
+        for needle in needles:
+            assert needle in self.text, (
+                f"the fault line no longer names {needle!r}, so an operator "
+                f"cannot act on it.\n--- captured ---\n{self.text}\n---"
+            )
+
+
+# ── the tool choice, argued as a test ────────────────────────────────────────
+
+def test_safe_exc_would_NOT_have_fixed_this():
+    """THE DISCRIMINATING CASE for (b).
+
+    `safe_exc` is what every reporter path uses and it is the obvious thing to
+    reach for here. It does not work: the reporter leak was a URL, which has a
+    grammar `redact_url` can take apart. This leak is a prompt. `safe_exc`
+    passes it through in full, and a fix built on it would have been green,
+    plausible, and still leaking.
+    """
+    out = safe_exc(ValueError(f"gate failed on {PROMPT!r}"))
+    assert CANARY in out, (
+        "safe_exc has changed and now strips arbitrary text; if that is "
+        "deliberate, this file's argument for safe_fault needs rewriting"
+    )
+    assert out.startswith("ValueError:")
+
+
+def test_safe_fault_keeps_the_type_and_the_location_and_drops_the_message():
+    try:
+        raise ValueError(f"gate failed on {PROMPT!r}")
+    except ValueError as exc:
+        out = safe_fault(exc)
+    assert CANARY not in out, out
+    assert out.startswith("ValueError at "), out
+    # The location is THIS module and a real line — derived from code objects,
+    # never from input. That is the actionable half a type alone does not give.
+    assert __name__ in out, out
+    assert out.rsplit(":", 1)[1].isdigit(), out
+
+
+def test_safe_fault_survives_an_exception_with_no_traceback():
+    out = safe_fault(RuntimeError(PROMPT))
+    assert CANARY not in out, out
+    assert out == "RuntimeError at unknown", out
+
+
+def test_safe_fault_and_exc_origin_never_raise():
+    class Exploding(Exception):
+        def __str__(self):
+            raise ValueError("boom")
+
+    assert isinstance(safe_fault(Exploding()), str)
+    assert isinstance(exc_origin(Exploding()), str)
+
+
+def test_exc_origin_is_bounded():
+    """An unbounded log field is an unbounded log field, even a safe one."""
+    try:
+        raise ValueError("x")
+    except ValueError as exc:
+        assert len(exc_origin(exc)) <= 120
+
+
+# ── the three hooks named in the finding ─────────────────────────────────────
+
+class _GateBoom(SensorExtension):
+    """A real quarantine gate: it looks at the scan text, and the lookup it
+    builds out of that text raises with the subject echoed back — which is what
+    json, re, pydantic and every HTTP client do."""
+
+    name = "acme-quarantine"
+
+    def gate(self, req):
+        raise ValueError(f"quarantine lookup failed for input {req.text!r}")
+
+
+class _TransformBoom(SensorExtension):
+    name = "acme-fleet-mode"
+
+    def transform_verdict(self, req, result):
+        raise RuntimeError(f"fleet mode lookup failed for input {req.text!r}")
+
+
+class _AttachBoom(SensorExtension):
+    name = "acme-attach"
+
+    def on_attach(self, sensor):
+        raise RuntimeError(f"attach failed loading config {PROMPT!r}")
+
+
+def test_gate_exception_does_not_put_the_prompt_in_the_log():
+    with _Capture() as cap:
+        s = Sensor(agent_id="f8", enforcement_mode="block",
+                   reporter=_NullReporter(), extensions=[_GateBoom()])
+        result = s.scan(PROMPT)
+    cap.assert_clean("gate()")
+    cap.assert_still_useful("acme-quarantine", "gate()", "ValueError")
+    # The fail-safe contract is untouched: the scan still completed.
+    assert result.action in ("allowed", "flagged", "blocked")
+
+
+def test_verdict_transform_exception_does_not_put_the_prompt_in_the_log():
+    with _Capture() as cap:
+        s = Sensor(agent_id="f8", enforcement_mode="block",
+                   reporter=_NullReporter(), extensions=[_TransformBoom()])
+        s.scan(PROMPT)
+    cap.assert_clean("transform_verdict()")
+    cap.assert_still_useful("acme-fleet-mode", "transform_verdict()",
+                            "RuntimeError")
+
+
+def test_on_attach_exception_does_not_put_the_payload_in_the_log():
+    """`on_attach` still RAISES — that contract is not being changed here.
+
+    What changed is that the sensor now says something on the way out, under
+    the same content rule as the other hooks, so a host that catches the
+    constructor exception and falls back to an unprotected path still leaves a
+    record. The exception itself carries the message to the CALLER, who owns the
+    disclosure decision for their own logging boundary.
+    """
+    with _Capture() as cap:
+        with pytest.raises(RuntimeError) as raised:
+            Sensor(agent_id="f8", enforcement_mode="block",
+                   reporter=_NullReporter(), extensions=[_AttachBoom()])
+    cap.assert_clean("on_attach()")
+    cap.assert_still_useful("acme-attach", "on_attach()", "RuntimeError")
+    # ... and the caller still gets the real thing.
+    assert CANARY in str(raised.value), (
+        "the re-raise was swallowed or rewritten; the caller can no longer "
+        "reach the message at their own boundary"
+    )
+
+
+# ── the neighbours the audit asked for ───────────────────────────────────────
+
+class _TrustBoom(SensorExtension):
+    name = "acme-trust"
+
+    def subject_trust(self, agent_id):
+        raise RuntimeError(f"trust lookup failed for {PROMPT!r}")
+
+
+class _BlocklistBoom(SensorExtension):
+    name = "acme-blocklist"
+
+    def blocked_urls(self):
+        raise RuntimeError(f"feed refresh failed: upstream said {PROMPT!r}")
+
+
+def test_subject_trust_exception_does_not_put_caller_text_in_the_log():
+    with _Capture() as cap:
+        s = Sensor(agent_id="f8", reporter=_NullReporter(),
+                   extensions=[_TrustBoom()])
+        assert s._subject_trust("f8") is None
+    cap.assert_clean("subject_trust()")
+    cap.assert_still_useful("acme-trust", "subject_trust()", "RuntimeError")
+
+
+def test_blocked_urls_exception_does_not_put_caller_text_in_the_log():
+    with _Capture() as cap:
+        s = Sensor(agent_id="f8", reporter=_NullReporter(),
+                   extensions=[_BlocklistBoom()])
+        s.effective_blocked_urls()
+    cap.assert_clean("blocked_urls()")
+    cap.assert_still_useful("acme-blocklist", "blocked_urls()", "RuntimeError")
+
+
+class _EscalatorBoom(Escalator):
+    """S3's version of the same shape: `scan` is handed `req.text` too."""
+
+    name = "acme-link"
+
+    def scan(self, req, local_result):
+        raise RuntimeError(f"link rejected the payload {req.text!r}")
+
+
+def test_escalator_exception_does_not_put_the_prompt_in_the_log():
+    local = ScanResult(action="flagged", score=0.3, category="test",
+                       rules=["R"], latency_ms=0)
+    req = ScanRequest(agent_id="f8", direction="input", text=PROMPT)
+    with _Capture() as cap:
+        result, escalation, reason = run_escalators([_EscalatorBoom()], req,
+                                                    local)
+    cap.assert_clean("escalator scan()")
+    cap.assert_still_useful("acme-link", "RuntimeError")
+    # The skip contract is untouched.
+    assert result is local
+    assert escalation == "skipped" and reason == "acme-link_unreachable"
+
+
+def test_breaker_on_trip_exception_does_not_put_caller_text_in_the_log():
+    """`on_trip` is arbitrary HOST code and fires from inside a scan."""
+    from xaidr.circuit_breaker import CircuitBreaker, _CircuitRuntime
+
+    def boom(payload):
+        raise RuntimeError(f"alerting failed while handling {PROMPT!r}")
+
+    runtime = _CircuitRuntime(
+        CircuitBreaker(violation_threshold=1, on_trip=boom), "f8", "block")
+    with _Capture() as cap:
+        runtime._fire_on_trip({"reason": "violation_threshold"})
+    cap.assert_clean("circuit_breaker on_trip")
+    cap.assert_still_useful("on_trip", "RuntimeError")
+
+
+def test_s2_condition_evaluator_exception_does_not_put_request_text_in_the_log():
+    """The S2 seam: the evaluator is extension code and sees the request."""
+    from xaidr.local_policy import evaluate_policy, set_policy_dict
+
+    def boom(request, value):
+        raise RuntimeError(
+            f"region lookup failed for {request['resource']['destination_identifier']!r}"
+        )
+
+    policy = set_policy_dict(
+        {"version": "1",
+         "defaults": {"effect": "allow", "unclassified": "allow"},
+         "rules": [{"id": "r1", "effect": "block",
+                    "match": {"tools": ["http_post"]},
+                    "conditions": {"region_is": "EU"}}]},
+        extra_conditions={"region_is": boom},
+    )
+    assert policy is not None, "policy with a registered condition was rejected"
+    with _Capture() as cap:
+        evaluate_policy(
+            policy, agent_id="f8", trust=None, tool_name="http_post",
+            impact_class="network_egress", impact_tier="high",
+            destination_type="url", destination_identifier=PROMPT,
+        )
+    cap.assert_clean("S2 condition evaluator")
+    cap.assert_still_useful("region_is", "RuntimeError")
+
+
+# ── the sinks the audit cleared, pinned so they stay cleared ─────────────────
+
+def test_escalator_health_keeps_its_message_because_it_cannot_see_content():
+    """The other half of the (b) decision, pinned.
+
+    `health()` takes no arguments and runs at CONSTRUCTION, before any scan, so
+    its message cannot echo scanned content. What it DOES carry is the backend
+    URL the link could not reach — the useful half of the diagnostic, and
+    exactly the shape `safe_exc` strips the credential out of. This test exists
+    so a later sweep that replaces every `safe_exc` with `safe_fault` has to
+    argue with something rather than silently cost an operator the reason their
+    link is down.
+    """
+    from xaidr.scanner.local import LocalScanner
+
+    class _HealthBoom(Escalator):
+        name = "acme-link"
+
+        def health(self):
+            raise RuntimeError(
+                "connection refused to https://brain.example.com/scan?token=SEKRIT")
+
+    with _Capture() as cap:
+        LocalScanner(escalators=(_HealthBoom(),))
+    text = cap.text
+    assert "SEKRIT" not in text, f"safe_exc did not redact the query value:\n{text}"
+    assert "brain.example.com" in text, (
+        f"the destination diagnostic was lost:\n{text}")
+    assert "connection refused" in text, (
+        f"the message was dropped; health() has no content path and does not "
+        f"need safe_fault:\n{text}")

--- a/xaidr/authz/policy.py
+++ b/xaidr/authz/policy.py
@@ -346,11 +346,18 @@ def _rule_matches(rule: dict, request: dict, evaluators: Optional[Mapping[str, A
                 if not evaluator(request, rule["conditions"][key]):
                     return False
             except Exception as exc:
+                # S2 evaluators are EXTENSION code and are handed the whole
+                # request, which carries the tool name and the destination
+                # identifier. Same rule as every other extension hook: the
+                # message is dropped, the type and the evaluator's own code
+                # location are kept. See `xaidr.reporters.safe_fault`.
+                from ..reporters import safe_fault
                 logger.error(
-                    "[xaidr] condition evaluator %r raised (%s: %s) — rule %r "
-                    "does NOT match. A condition that cannot answer must not "
-                    "widen the rule it was written to narrow.",
-                    key, type(exc).__name__, exc, rule.get("id"),
+                    "[xaidr] condition evaluator %r raised (%s) [message "
+                    "suppressed: may contain request content] — rule %r does "
+                    "NOT match. A condition that cannot answer must not widen "
+                    "the rule it was written to narrow.",
+                    key, safe_fault(exc), rule.get("id"),
                 )
                 return False
 

--- a/xaidr/circuit_breaker.py
+++ b/xaidr/circuit_breaker.py
@@ -40,6 +40,8 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
+from .reporters import safe_fault
+
 logger = logging.getLogger("xaidr.circuit_breaker")
 
 # Verdict surfaced by every scan while the circuit is open in block mode.
@@ -363,9 +365,14 @@ class _CircuitRuntime:
         try:
             cb(payload)
         except Exception as exc:
+            # `on_trip` is arbitrary HOST code and it fires from inside a scan,
+            # so whatever it raises is both outside our control and within
+            # reach of the content being scanned. Type and location only —
+            # `safe_fault`, the same treatment the extension hooks get.
             logger.warning(
-                "xaidr: circuit_breaker on_trip callback raised (%s: %s)",
-                type(exc).__name__, exc,
+                "xaidr: circuit_breaker on_trip callback raised (%s) "
+                "[message suppressed: may contain scanned content]",
+                safe_fault(exc),
             )
 
     # Set by the sensor so trip/close events reach telemetry. Left as a no-op

--- a/xaidr/escalation.py
+++ b/xaidr/escalation.py
@@ -41,6 +41,8 @@ import threading
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from .reporters import safe_fault
+
 logger = logging.getLogger("xaidr.escalation")
 
 __all__ = ["Escalator", "HealthReport", "run_escalators"]
@@ -150,10 +152,16 @@ def run_escalators(escalators, req, local_result):
             continue
         if status == "error":
             skipped_reason = skipped_reason or f"{name}_unreachable"
+            # Message suppressed for the same reason `_extension_failed` does
+            # it: `scan(req, local_result)` is handed `ScanRequest.text`, so a
+            # link that raises while looking at the prompt can put the prompt in
+            # its own message, and this line ships to the host's pipeline.
+            # Type plus the code location inside the link — see `safe_fault`.
             logger.error(
-                "xaidr: escalator %r raised (%s: %s) — SKIPPED. The local "
-                "verdict stands and this scan was NOT given a second opinion.",
-                name, type(value).__name__, value,
+                "xaidr: escalator %r raised (%s) [message suppressed: may "
+                "contain scanned content] — SKIPPED. The local verdict stands "
+                "and this scan was NOT given a second opinion.",
+                name, safe_fault(value),
             )
             continue
         if value is not None:

--- a/xaidr/extensions.py
+++ b/xaidr/extensions.py
@@ -31,6 +31,15 @@ THE FOUR RULES THIS MODULE ENCODES:
    runtime degradation), and a ``transform_verdict`` that STRENGTHENS a verdict
    raises (that is a contract violation, not an environment fault).
 
+   THE FAULT LINE NEVER CARRIES THE EXCEPTION MESSAGE. Every hook here has been
+   handed content the sensor is scanning — ``gate`` and ``transform_verdict``
+   receive ``ScanRequest.text`` outright — and an exception message is routinely
+   built by interpolating the value that caused the fault. The extension is
+   entitled to that content; the sensor's log is not, and it ships to the host's
+   pipeline like any other. What is logged is the extension name, the hook, the
+   exception TYPE and the code location inside the extension
+   (``xaidr.reporters.safe_fault``).
+
 WHAT THE VIEWS DO NOT CARRY. Nothing here hands an extension the raw prompt
 beyond what the hook already receives as the scan input (``ScanRequest.text``,
 which the scan already has). Destinations are host-only; tool arguments and
@@ -147,6 +156,14 @@ class SensorExtension:
         attach has not degraded, it has failed to install, and a deployment that
         believes it installed an enterprise control it did not have is the
         failure this whole module exists to prevent.
+
+        The sensor also logs the failure at ERROR on the way out, so a host that
+        catches this exception and falls back still leaves a record. That line
+        carries the extension name, the exception TYPE and the code location —
+        never the exception MESSAGE, which is the same content rule every other
+        hook's fault line follows (see ``Sensor._extension_failed``). The
+        message reaches the CALLER, on the raised exception, where they own the
+        disclosure decision.
         """
 
     # ── S5 ───────────────────────────────────────────────────────────────────

--- a/xaidr/reporters.py
+++ b/xaidr/reporters.py
@@ -177,9 +177,72 @@ def redact_text(value: Any) -> str:
 
 
 def safe_exc(exc: BaseException) -> str:
-    """What to log for an exception: its type and its redacted message."""
+    """What to log for an exception: its type and its redacted message.
+
+    The right tool when the exception comes from a library WE called on a
+    destination WE handed it, and the destination is the diagnostic: a webhook
+    that 500s, an OTel exporter that cannot connect, a file that will not open.
+    The message is kept because it is the useful part, and `redact_text` can
+    strip the one secret-bearing shape (a URL) that such a message carries.
+
+    It is the WRONG tool for an exception raised by third-party code that has
+    been handed scanned content — see `safe_fault`.
+    """
     try:
         return f"{type(exc).__name__}: {redact_text(exc)}"
+    except Exception:
+        return "<unloggable-exception>"
+
+
+#: Cap on the rendered origin. A module name comes from a code object and is
+#: not attacker-steerable, but a log field with no bound is a log field with no
+#: bound.
+_ORIGIN_CAP = 120
+
+
+def exc_origin(exc: BaseException) -> str:
+    """Where an exception was raised, as ``module:lineno``. Never its message.
+
+    The DEEPEST frame in the traceback, which for a fault inside third-party
+    code is that code's own module and line — the thing its author needs.
+
+    Both halves come from code objects: `__name__` off the frame globals and
+    `tb_lineno` off the traceback. Neither is derived from input, which is
+    exactly what makes this safe to log at a sink where the message is not.
+    Returns ``"unknown"`` for an exception raised without a traceback.
+    """
+    try:
+        origin = "unknown"
+        tb = getattr(exc, "__traceback__", None)
+        while tb is not None:
+            frame = tb.tb_frame
+            origin = f"{frame.f_globals.get('__name__', '?')}:{tb.tb_lineno}"
+            tb = tb.tb_next
+        return origin[:_ORIGIN_CAP]
+    except Exception:
+        return "unknown"
+
+
+def safe_fault(exc: BaseException) -> str:
+    """What to log for an exception raised by code we do not control, on a path
+    that has been handed scanned content: ``TypeName at module:line``.
+
+    THE MESSAGE IS DROPPED ENTIRELY, not redacted. That is the difference from
+    `safe_exc` and it is not a matter of degree. A reporter's failure carries a
+    URL — a shape with a grammar, which `redact_url` can take apart. An
+    extension's `gate()` is handed `ScanRequest.text` and may raise with any
+    part of it embedded in any wording; a caller's exception text has no
+    grammar, so there is no pattern that separates the prompt from the
+    diagnostic. Sanitising arbitrary text is not a thing that can be done, and
+    the only honest treatment is to not log it.
+
+    What survives is what an operator can act on and an attacker cannot steer:
+    the exception TYPE and the CODE LOCATION inside the failing extension. The
+    caller of the hook still has the exception object and may log its message at
+    their own boundary, where they own the disclosure decision.
+    """
+    try:
+        return f"{type(exc).__name__} at {exc_origin(exc)}"
     except Exception:
         return "<unloggable-exception>"
 

--- a/xaidr/scanner/local.py
+++ b/xaidr/scanner/local.py
@@ -390,11 +390,21 @@ class LocalScanner:
             try:
                 report = esc.health()
             except Exception as exc:
+                # `safe_exc` here, NOT `safe_fault`, and the difference is the
+                # audited one. `health()` takes no arguments and runs at
+                # CONSTRUCTION, before any scan — there is no scanned content in
+                # the process for its message to echo. What such a message DOES
+                # carry is the backend URL the link could not reach, which is
+                # both the useful half of the diagnostic and exactly the shape
+                # `redact_text` strips the credential out of. Dropping the
+                # message here would cost an operator the reason their link is
+                # down and protect nothing.
+                from ..reporters import safe_exc
                 logger.error(
                     "xaidr: escalator %r raised from health() at construction "
-                    "(%s: %s). The link is REGISTERED but has not confirmed it "
+                    "(%s). The link is REGISTERED but has not confirmed it "
                     "is answering; scans will record 'skipped' if it keeps "
-                    "failing.", name, type(exc).__name__, exc,
+                    "failing.", name, safe_exc(exc),
                 )
                 continue
             if report is None or not getattr(report, "healthy", False):

--- a/xaidr/sensor.py
+++ b/xaidr/sensor.py
@@ -44,7 +44,7 @@ from .circuit_breaker import (
 from .enforcement import MONITOR as _MONITOR, resolve as _resolve_enforcement
 from .escalation import Escalator
 from .extensions import DestinationView, ScanRequest, SensorExtension
-from .reporters import Reporter
+from .reporters import Reporter, safe_fault
 from .scanner.a2a_structural import A2AStructuralValidator, A2AIdTracker
 from .scanner.command_parse import reconstruct as _reconstruct_command
 from .scanner.privilege_action import scan_privileged_action as _privilege_findings
@@ -672,9 +672,30 @@ class DelphiSensor:
         # conditions are known before the policy loads, and on_attach still
         # sees a finished object.
         for extension in self._extensions:
-            # NOT wrapped: a fault here is a construction failure and raises.
-            # See SensorExtension.on_attach for why this one hook is different.
-            extension.on_attach(self)
+            # NOT wrapped into a degradation: a fault here is a construction
+            # failure and RAISES, unchanged. See SensorExtension.on_attach for
+            # why this one hook is different.
+            #
+            # It is LOGGED on the way out, under the same content rule as every
+            # other extension fault, for two reasons. A host that catches the
+            # constructor exception and falls back to an unprotected path
+            # otherwise leaves no record that an enterprise control failed to
+            # install. And the re-raise is what keeps the message available to
+            # exactly one party: the caller, at their own logging boundary,
+            # where they own the disclosure decision. The sensor's own sink gets
+            # the type and the location and nothing else.
+            try:
+                extension.on_attach(self)
+            except Exception as exc:
+                name = getattr(extension, "name", type(extension).__name__)
+                logger.error(
+                    "xaidr: extension %r raised in on_attach() (%s) [message "
+                    "suppressed: may contain caller-supplied content]. "
+                    "CONSTRUCTION FAILED — this sensor was NOT built and the "
+                    "exception is re-raised to the caller.",
+                    name, safe_fault(exc),
+                )
+                raise
 
     # ── extensions (S1/S5/S6) ────────────────────────────────────────────
     # Every hook below except on_attach is fail-SAFE: a fault degrades to "this
@@ -806,6 +827,21 @@ class DelphiSensor:
         enterprise gate that is throwing is not protecting anything, and the
         sensor will keep returning healthy-looking verdicts without it. That is
         the ``_breaker_counter_failed`` lesson applied to extension code.
+
+        THE EXCEPTION MESSAGE IS NEVER LOGGED, for the reason ``_emit_scan_error``
+        already gives about the scan path: an exception message is routinely
+        built by interpolating the value that caused the fault, and every hook
+        reached through here has been handed scanned content — ``gate`` and
+        ``transform_verdict`` receive ``ScanRequest.text`` directly. An
+        extension is ENTITLED to that content; this log line is not, and it
+        ships to the host's pipeline like any other.
+
+        `safe_fault`, not `safe_exc`: `safe_exc` redacts URLs out of a message
+        it otherwise keeps, which is right for a reporter failing against a
+        destination and useless here, where the leaked value is a prompt and has
+        no shape to match. What is logged instead is the exception TYPE and the
+        code location INSIDE the extension — neither derived from input, and
+        together the thing an operator hands to the extension's author.
         """
         name = getattr(extension, "name", type(extension).__name__)
         key = (name, hook)
@@ -813,10 +849,11 @@ class DelphiSensor:
             return
         self._extension_faults.add(key)
         logger.error(
-            "xaidr: extension %r raised in %s() (%s: %s). THIS CONTROL IS INERT "
-            "until the sensor is rebuilt — the scan continued on the open "
-            "verdict. This message is logged once per extension per hook.",
-            name, hook, type(exc).__name__, exc,
+            "xaidr: extension %r raised in %s() (%s) [message suppressed: may "
+            "contain scanned content]. THIS CONTROL IS INERT until the sensor "
+            "is rebuilt — the scan continued on the open verdict. This message "
+            "is logged once per extension per hook.",
+            name, hook, safe_fault(exc),
         )
 
     def _build_scan_request(self, direction: str, **fields) -> ScanRequest:


### PR DESCRIPTION
Seven sinks logged a caller-supplied exception verbatim. An extension
whose gate raised with the scanned prompt in the message put that prompt
in the log. safe_exc was not the fix: it redacts URLs only, so a fix
built on it would have been green and still leaking. Added safe_fault,
which drops the message entirely and reports type plus code location.

Signed-off-by: Anirudh Kotaru <anirudh@delphisecurity.ai>
