### PR TITLE
fix(policy): reject wrong-typed policy values instead of loading them inert

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -398,5 +398,71 @@ naming the key, the rule, and the nearest valid field, so a typo like
 unrecognized key matches nothing, which would load cleanly and enforce nothing;
 the policy is refused instead and the sensor falls through to detection-only.
 
+### The property: a rule that cannot match anything never loads quietly
+
+Getting the key right is only half of it. A **wrong-typed value** disarms a rule
+just as completely:
+
+```yaml
+match:
+  tools: deploy        # ✗ a string, not a list — matches NOTHING
+  tools: ["deploy"]    # ✓
+```
+
+Match values are lists of glob patterns, and the evaluator returns "no match"
+for anything that is not a list. Before this was validated, the rule above
+loaded, the sensor logged `loaded local policy (1 rules)`, and `deploy` was
+never blocked. The operator believed a control was active.
+
+Every shape with that consequence is now refused at load, with an error naming
+the field and showing the correction:
+
+| Where | Expected | Rejected shapes |
+|---|---|---|
+| `match:` field values (all eight) | non-empty list of string patterns | scalar, number, `null`, `[]`, mapping, unquoted `yes`/`no`, nested list |
+| `match:` / `conditions:` block | mapping | string (one missed indent), list, number |
+| `conditions: min_chain_tier_above` | number | non-numeric string, `null`, list, mapping, bool |
+| `defaults:` block | mapping | string, list, number |
+| `defaults:` keys/values | `effect`, `unclassified` ∈ the four effects | unknown key, wrong case, non-effect value |
+| `rules:` | list | mapping, string, `null`, number |
+| a rule | at least one match field or condition | no `match:` and no `conditions:` |
+
+Two of these are worse than an inert rule, because the rule still fires:
+
+- **`null` skips a narrower.** `match: {tools: , agents: ["billing"]}` drops the
+  `tools` restriction and blocks *everything* the billing agent does.
+- **A non-mapping `defaults:` is discarded.** `defaults: block` — a plausible
+  shorthand — reverted the whole deployment to the shipped `effect: allow`,
+  turning deny-by-default into allow-by-default with nothing logged.
+
+A policy with no rules and the shipped defaults still loads (a `defaults:`-only
+posture is legitimate) but **warns**, because it is indistinguishable from a
+policy whose `rules:` was lost to an indent.
+
+#### Why a wrong type is rejected, not coerced
+
+Coercing `tools: deploy` to `tools: ["deploy"]` is friendlier, and it was
+considered. It loses on three counts:
+
+1. **It only answers one shape of seven.** There is no defensible coercion for
+   `tools: []`, for a mapping, for `null`, or for a `match:` block that is
+   itself a string. Coercion would fix the tidiest case and leave the rest of
+   the class silently broken — while making the file look validated.
+2. **It guesses at intent, in the arming direction.** Is `tools: "a,b"` one tool
+   or two? Coercion silently starts *enforcing* a rule that no one reviewed in
+   the form the engine actually runs. An inert rule is at least inert.
+3. **Rejection costs no enforcement.** This is the argument that settles it. A
+   rule in one of these states was already matching nothing, and the rejection
+   path lands on exactly the same detection-only fallback that the inert rule
+   was already delivering. Nothing that was being enforced stops being enforced.
+   The whole delta is that the operator is now told.
+
+The cost is real but narrower than it looks: rejection refuses the **whole**
+policy, so one malformed rule takes its healthy siblings with it. That follows
+the existing contract for `trust_below` and unknown keys, and for the same
+reason — half a policy is a state nobody authored, and the surviving half can
+be the `allow` exceptions to the `block` rules that were dropped. Detection-only
+is a known floor; a partially applied deny-list is not.
+
 ---
 

--- a/tests/test_f5_policy_type_mismatch.py
+++ b/tests/test_f5_policy_type_mismatch.py
@@ -1,0 +1,474 @@
+"""F5 · a policy rule must never load successfully and silently never match.
+
+The audit finding: `match: {tools: "deploy"}` — a scalar where a list belongs —
+parsed without error, logged `loaded local policy (1 rules)`, and then matched
+nothing, because `_glob_any` returns False for any non-list. The operator writes
+a control, it validates, and it does nothing. That is the worst failure mode a
+policy engine has, so this file asserts the property directly:
+
+    for every field in the schema, a wrong-typed value is either REJECTED at
+    load or the rule FIRES. Never accepted-and-inert.
+
+`test_property_no_field_is_accepted_and_inert` is that sentence as code, over
+the cross product of every match field and every wrong shape. The named tests
+around it exist so a failure says WHICH mistake regressed; the property test is
+what makes the file non-vacuous if someone adds a field and forgets a case.
+
+Both directions of the field list are derived from `_MATCH_FIELDS`, the
+evaluator's own source of truth, so a field added there is covered here without
+anyone remembering to. `_request()` asserts that derivation actually holds —
+without it the "still fires" control would pass vacuously for a new field.
+"""
+import logging
+
+import pytest
+
+from xaidr import Sensor
+from xaidr.authz.policy import (
+    _MATCH_FIELDS,
+    build_request,
+    evaluate,
+    parse_action_policy,
+)
+
+AUTHZ = "xaidr.authz"
+
+# One distinct value per match field, so a rule keyed on any single field can be
+# shown to fire, and a wrong-typed one shown not to.
+_VALUE = {f: f"v-{f}" for f in _MATCH_FIELDS}
+
+
+def _request():
+    r = build_request(
+        agent_id=_VALUE["agents"],
+        trust=None,
+        tool_name=_VALUE["tools"],
+        impact_class=_VALUE["impact_class"],
+        impact_tier=_VALUE["impact_tier"],
+        destination_type=_VALUE["destination_type"],
+        destination_identifier=_VALUE["destination_identifier"],
+        context={"mcp_server": _VALUE["mcp_server"]},
+        category=_VALUE["category"],
+    )
+    for field, (section, key) in _MATCH_FIELDS.items():
+        assert r[section].get(key) == _VALUE[field], (
+            f"match field {field!r} is not populated in this fixture's request, "
+            f"so every 'still fires' assertion for it would pass vacuously. "
+            f"A field was added to _MATCH_FIELDS without extending _request()."
+        )
+    return r
+
+
+def _policy(rule, defaults=None):
+    return {
+        "version": "1",
+        "defaults": defaults if defaults is not None else {"effect": "allow"},
+        "rules": [rule],
+    }
+
+
+def _rule(match=..., conditions=..., **kw):
+    r = {"id": "the-rule", "effect": "block", "message": "denied"}
+    if match is not ...:
+        r["match"] = match
+    if conditions is not ...:
+        r["conditions"] = conditions
+    r.update(kw)
+    return r
+
+
+# Every shape a match value can wrongly take. Each maps the correct value to a
+# wrong one, so the cases stay meaningful per-field.
+WRONG_MATCH_VALUES = [
+    ("scalar-str", lambda good: good),            # the reported F5 case
+    ("scalar-int", lambda good: 42),
+    ("null", lambda good: None),                  # YAML `tools:` with no value
+    ("empty-list", lambda good: []),
+    ("mapping", lambda good: {"name": good}),
+    ("list-of-bool", lambda good: [True]),        # unquoted YAML yes/on
+    ("nested-list", lambda good: [[good]]),
+]
+
+ALL_CASES = [
+    (field, shape, make)
+    for field in sorted(_MATCH_FIELDS)
+    for shape, make in WRONG_MATCH_VALUES
+]
+
+
+# ── (a) the reproduction, verbatim ───────────────────────────────────────────
+
+def test_reported_case_scalar_tools_is_rejected(caplog):
+    """The exact rule from the finding: `tools: "deploy"` instead of ["deploy"]."""
+    raw = _policy(_rule({"tools": "deploy"}))
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy(raw)
+    assert parsed is None, (
+        "the reported F5 rule loaded successfully; it will now be reported to "
+        "the operator as an active control and will match nothing"
+    )
+    text = caplog.text
+    assert "tools" in text and "the-rule" in text
+    assert '["deploy"]' in text, f"error does not show the correction: {text!r}"
+
+
+def test_reported_case_correct_form_still_fires():
+    """The discriminating control: the LIST form must be untouched."""
+    parsed = parse_action_policy(_policy(_rule({"tools": [_VALUE["tools"]]})))
+    assert parsed is not None
+    assert evaluate(parsed, _request()).decision == "blocked"
+
+
+# ── (e) every match field × every wrong shape ────────────────────────────────
+
+@pytest.mark.parametrize("field,shape,make", ALL_CASES,
+                         ids=[f"{f}-{s}" for f, s, _ in ALL_CASES])
+def test_wrong_typed_match_value_is_rejected(field, shape, make, caplog):
+    raw = _policy(_rule({field: make(_VALUE[field])}))
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy(raw)
+    assert parsed is None, (
+        f"match.{field} = {make(_VALUE[field])!r} ({shape}) loaded as a valid "
+        f"policy — the rule is silently dead and the operator is not told"
+    )
+    text = caplog.text
+    assert field in text, f"error does not name the field: {text!r}"
+    assert "the-rule" in text, f"error does not name the rule id: {text!r}"
+    assert "REJECTED" in text
+
+
+@pytest.mark.parametrize("field", sorted(_MATCH_FIELDS))
+def test_correctly_typed_match_value_still_fires(field):
+    """(e) control against over-rejection: the validator must not eat real rules.
+
+    Derived from _MATCH_FIELDS, so a newly added field is covered here without
+    anyone remembering to add it.
+    """
+    parsed = parse_action_policy(_policy(_rule({field: [_VALUE[field]]})))
+    assert parsed is not None, f"a correct {field}: [..] rule was rejected"
+    assert evaluate(parsed, _request()).decision == "blocked", (
+        f"a correct {field}: [..] rule loaded but did not fire"
+    )
+
+
+@pytest.mark.parametrize("field,shape,make", ALL_CASES,
+                         ids=[f"{f}-{s}" for f, s, _ in ALL_CASES])
+def test_property_no_field_is_accepted_and_inert(field, shape, make):
+    """(d) THE PROPERTY, stated once over the whole cross product.
+
+    Independent of mechanism: whatever the loader decides to do with a wrong
+    type, the one outcome it may not produce is a policy that loads and cannot
+    act. Rejecting satisfies this; so would coercing. Accepting does not.
+    """
+    parsed = parse_action_policy(_policy(_rule({field: make(_VALUE[field])})))
+    if parsed is None:
+        return  # rejected — loud, safe
+    decision = evaluate(parsed, _request()).decision
+    assert decision == "blocked", (
+        f"match.{field} = {make(_VALUE[field])!r} ({shape}) was ACCEPTED "
+        f"({parsed['rules']!r}) and then did not fire on input it names "
+        f"(decision={decision!r}). This is the F5 failure mode: the operator "
+        f"believes a control is active and it is inert."
+    )
+
+
+@pytest.mark.parametrize("field", [f for f in sorted(_MATCH_FIELDS) if f != "tools"])
+def test_null_field_does_not_silently_widen_a_rule(field, caplog):
+    """The `null` shape does not go inert — it goes the other way.
+
+    `_rule_matches` SKIPS a None field, so `match: {tools: , agents: [a]}` drops
+    the tools narrower and blocks everything agent `a` does. The rule fires, so
+    the accepted-and-inert property above would not catch it; this asserts the
+    load is refused rather than the rule silently widened.
+    """
+    raw = _policy(_rule({"tools": None, field: [_VALUE[field]]}))
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy(raw)
+    assert parsed is None, (
+        f"`tools:` with no value loaded beside {field}: the rule now fires on "
+        f"every tool, not the ones the operator listed"
+    )
+    assert "WIDENS" in caplog.text, caplog.text
+
+
+# ── (b) the match:/conditions: BLOCKS themselves ─────────────────────────────
+
+@pytest.mark.parametrize("block", ["match", "conditions"])
+@pytest.mark.parametrize("value,shape", [
+    ("tools: deploy", "scalar-str"),      # one missed indent turns it into a string
+    (["tools"], "list"),
+    (42, "int"),
+])
+def test_non_mapping_block_is_rejected(block, value, shape, caplog):
+    rule = _rule({"tools": [_VALUE["tools"]]})
+    rule[block] = value
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy(_policy(rule))
+    assert parsed is None, (
+        f"a {shape} '{block}:' block loaded; it is discarded, so the rule runs "
+        f"with no {block} at all"
+    )
+    assert block in caplog.text and "the-rule" in caplog.text
+
+
+def test_scalar_conditions_block_cannot_smuggle_trust_below_past_its_guard(caplog):
+    """The nastiest of the block cases, and why it is not just cosmetic.
+
+    A-11 rejects `conditions: {trust_below: ...}` because it can never fire in
+    open. One missed indent makes `conditions:` a STRING, the block is replaced
+    with {} before the guard reads it, and the rule loads — armed, with the
+    condition the operator wrote to narrow it silently gone.
+    """
+    rule = _rule({"tools": [_VALUE["tools"]]})
+    rule["conditions"] = "trust_below: 0.5"
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy(_policy(rule))
+    assert parsed is None, (
+        "a stringified conditions: block bypassed the trust_below rejection AND "
+        "dropped the condition — the rule fires where the operator excluded it"
+    )
+
+
+# ── (b) conditions: VALUES ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize("value,shape", [
+    ("high", "non-numeric-str"),
+    ([1], "list"),
+    (None, "null"),
+    ({"tier": 1}, "mapping"),
+    (True, "bool"),
+])
+def test_non_numeric_min_chain_tier_above_is_rejected(value, shape, caplog):
+    """`int(value)` is wrapped in try/except at evaluation time and returns
+    False — another load-clean, never-fires rule."""
+    raw = _policy(_rule({"tools": [_VALUE["tools"]]},
+                        {"min_chain_tier_above": value}))
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy(raw)
+    assert parsed is None, f"min_chain_tier_above={value!r} ({shape}) loaded"
+    assert "min_chain_tier_above" in caplog.text
+
+
+@pytest.mark.parametrize("value", [1, 0, "1"])
+def test_numeric_min_chain_tier_above_still_loads_and_fires(value):
+    """Control: including the numeric-string form, which works today."""
+    parsed = parse_action_policy(
+        _policy(_rule({"tools": [_VALUE["tools"]]}, {"min_chain_tier_above": value})))
+    assert parsed is not None
+    req = _request()
+    req["context"]["least_privileged_tier"] = 4
+    assert evaluate(parsed, req).decision == "blocked"
+
+
+# ── (d) the general case: a rule with nothing to match on ────────────────────
+
+@pytest.mark.parametrize("rule", [
+    {"id": "bare", "effect": "block"},
+    {"id": "bare", "effect": "block", "match": {}},
+    {"id": "bare", "effect": "block", "match": {}, "conditions": {}},
+])
+def test_rule_with_no_matchers_at_all_is_rejected(rule, caplog):
+    """Catches the shapes nobody enumerated. `_rule_matches` already returns
+    False for these — at evaluation time, invisibly. Same verdict, moved to
+    load, where there is an operator to read it."""
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy(_policy(rule))
+    assert parsed is None
+    assert "NEVER fire" in caplog.text
+
+
+# ── (b) defaults: — the block with no rule to attach the blame to ────────────
+
+@pytest.mark.parametrize("defaults,shape", [
+    ("block", "scalar-str"),
+    (["block"], "list"),
+    (0, "int"),
+])
+def test_non_mapping_defaults_is_rejected(defaults, shape, caplog):
+    """The highest-consequence case in the file, and it involves no rule at all.
+
+    A non-mapping `defaults:` was discarded and the policy fell back to the
+    SHIPPED defaults, so `defaults: block` silently turned a deny-by-default
+    deployment into an allow-by-default one.
+    """
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy({
+            "version": "1", "defaults": defaults, "rules": [],
+        })
+    assert parsed is None, (
+        f"defaults: {defaults!r} ({shape}) loaded as allow-by-default; the "
+        f"operator wrote a deny-by-default policy and got the opposite"
+    )
+    assert "allow-by-default" in caplog.text
+
+
+def test_unknown_defaults_key_is_rejected(caplog):
+    """`defaults: {efect: block}` — same consequence, via a typo instead."""
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy({
+            "version": "1", "defaults": {"efect": "block"}, "rules": [],
+        })
+    assert parsed is None
+    assert "efect" in caplog.text and "effect" in caplog.text
+
+
+@pytest.mark.parametrize("key", ["effect", "unclassified"])
+@pytest.mark.parametrize("value", ["BLOCK", "blok", ["block"], None, 1])
+def test_invalid_defaults_effect_is_rejected_loudly(key, value, caplog):
+    """These were already rejected — but SILENTLY, with the reason logged only
+    as a generic 'malformed' by the caller. The reason is now named."""
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy({
+            "version": "1", "defaults": {key: value}, "rules": [],
+        })
+    assert parsed is None
+    assert key in caplog.text, f"rejection does not say which key was bad: {caplog.text!r}"
+
+
+def test_defaults_only_policy_still_loads_and_enforces():
+    """Control: a rules-less deny-by-default posture is legitimate."""
+    parsed = parse_action_policy({
+        "version": "1", "defaults": {"effect": "block"}, "rules": [],
+    })
+    assert parsed is not None
+    assert evaluate(parsed, _request()).decision == "blocked"
+
+
+def test_policy_that_can_do_nothing_is_loud_without_being_rejected(caplog):
+    """(d) applied to the whole file rather than one rule.
+
+    No rules plus the shipped defaults enforces nothing the operator wrote, and
+    is indistinguishable from a policy whose `rules:` was lost to an indent.
+    Not a rejection — a defaults-only policy is valid and this one is merely
+    empty — but it must not load in silence.
+    """
+    with caplog.at_level(logging.WARNING, logger=AUTHZ):
+        parsed = parse_action_policy({"version": "1"})
+    assert parsed is not None
+    assert "cannot change any decision" in caplog.text
+
+
+# ── (b) top level ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("rules,shape", [
+    ({"a": {}}, "mapping"), ("no-deploy", "scalar-str"), (None, "null"), (7, "int"),
+])
+def test_non_list_rules_is_rejected_loudly(rules, shape, caplog):
+    """Already rejected, but with nothing logged from this module — the operator
+    saw only the caller's generic 'malformed or unsupported'."""
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        parsed = parse_action_policy({"version": "1", "rules": rules})
+    assert parsed is None
+    assert "rules" in caplog.text, f"rejection reason not logged: {caplog.text!r}"
+
+
+def test_non_mapping_policy_is_rejected_loudly(caplog):
+    with caplog.at_level(logging.ERROR, logger=AUTHZ):
+        assert parse_action_policy("version: 1") is None
+    assert "must be a mapping" in caplog.text
+
+
+# ── every error path must actually RENDER ────────────────────────────────────
+
+def test_every_rejection_message_formats():
+    """A guard the fix itself needed.
+
+    `logger.error(fmt, *args)` formats lazily: a %-placeholder/argument count
+    mismatch is swallowed by the logging module and printed to stderr, so the
+    rejection is silent to anyone reading logs — the exact failure class this
+    file exists to close, reintroduced in the code that closes it. (Three of
+    these were present in the first draft of the fix and found by a probe, not
+    by a test.) This forces every rejection message through getMessage().
+    """
+    bad_policies = [
+        "version: 1",
+        {"version": "1", "rules": "x"},
+        {"version": "1", "defaults": "block", "rules": []},
+        {"version": "1", "defaults": {"efect": "block"}, "rules": []},
+        {"version": "1", "defaults": {"effect": "nope"}, "rules": []},
+        _policy(_rule({}, {})),
+        _policy(_rule("tools: x")),
+        _policy(_rule({"tools": [_VALUE["tools"]]}, "trust_below: 1")),
+        _policy(_rule({"tools": [_VALUE["tools"]]}, {"min_chain_tier_above": "hi"})),
+        _policy(_rule({"tools": [_VALUE["tools"]]}, {"trust_below": 0.5})),
+        _policy(_rule({"tool": ["x"]})),
+    ] + [_policy(_rule({f: make(_VALUE[f])})) for f, _, make in ALL_CASES]
+
+    records = []
+    handler = logging.Handler()
+    handler.emit = records.append
+    log = logging.getLogger(AUTHZ)
+    log.addHandler(handler)
+    try:
+        for raw in bad_policies:
+            assert parse_action_policy(raw) is None, raw
+    finally:
+        log.removeHandler(handler)
+
+    assert len(records) >= len(bad_policies)
+    for rec in records:
+        try:
+            rendered = rec.getMessage()
+        except Exception as exc:  # pragma: no cover - the thing being prevented
+            pytest.fail(
+                f"a rejection message cannot be formatted ({exc!r}) — logging "
+                f"would swallow it and the policy would be refused in silence. "
+                f"fmt={rec.msg!r} args={rec.args!r}"
+            )
+        assert "%s" not in rendered and "%r" not in rendered, rendered
+
+
+# ── (a) end to end, the way an operator meets it ─────────────────────────────
+
+MALFORMED_YAML = """\
+version: "1"
+defaults:
+  effect: allow
+rules:
+  - id: no-deploy
+    effect: block
+    message: "deploy is not permitted"
+    match:
+      tools: "deploy"
+"""
+
+
+def _load(tmp_path, text):
+    from xaidr.local_policy import load_policy
+    p = tmp_path / "xaidr-policy.yaml"
+    p.write_text(text, encoding="utf-8")
+    return load_policy(str(p), auto_default=False)
+
+
+def test_end_to_end_yaml_file_is_refused_not_reported_as_loaded(tmp_path, caplog):
+    yaml = pytest.importorskip("yaml")  # noqa: F841 - policy extra
+    with caplog.at_level(logging.INFO):
+        policy = _load(tmp_path, MALFORMED_YAML)
+    assert policy is None, (
+        "the malformed policy FILE loaded — this is what the operator actually "
+        "does, and the sensor is now enforcing a rule that cannot match"
+    )
+    assert "loaded local policy" not in caplog.text, (
+        "the loader still reports SUCCESS for a policy whose only rule cannot "
+        f"fire: {caplog.text!r}"
+    )
+    assert "tools" in caplog.text
+
+
+def test_end_to_end_corrected_yaml_loads_and_blocks(tmp_path):
+    pytest.importorskip("yaml")
+    policy = _load(tmp_path, MALFORMED_YAML.replace('"deploy"', '["deploy"]'))
+    assert policy is not None
+    from xaidr.local_policy import evaluate_policy
+    assert evaluate_policy(
+        policy, agent_id="a", trust=None, tool_name="deploy",
+        impact_class="deployment", impact_tier="destructive",
+        destination_type="internal", destination_identifier="prod",
+    ).decision == "blocked"
+
+
+def test_sensor_set_policy_reports_false_for_the_malformed_rule():
+    """The programmatic path returns a boolean the caller can act on."""
+    s = Sensor(agent_id="f5", enforcement_mode="monitor")
+    assert s.set_policy(_policy(_rule({"tools": "deploy"}))) is False
+    assert s.set_policy(_policy(_rule({"tools": ["deploy"]}))) is True

--- a/tests/test_inert_stubs_audit.py
+++ b/tests/test_inert_stubs_audit.py
@@ -249,20 +249,34 @@ def test_all_documented_match_fields_together_still_load_and_fire():
                             mcp_server="srv-a").action == "blocked"
 
 
-def test_rule_with_no_match_block_still_loads():
-    """(f) control: a rule with no match: at all is still a valid load."""
-    assert _sensor().set_policy({
-        "version": "1", "defaults": {"effect": "allow"},
-        "rules": [{"id": "bare", "effect": "allow"}],
-    }) is True
+@pytest.mark.parametrize("rule,label", [
+    ({"id": "bare", "effect": "allow"}, "no match: block at all"),
+    ({"id": "empty", "effect": "block", "match": {}, "conditions": {}}, "empty blocks"),
+])
+def test_rule_with_nothing_to_match_on_is_rejected(rule, label, caplog):
+    """CONTRACT CHANGE (F5 (d)): these two used to assert `is True`.
 
+    They were written as A-11 scope guards — "an empty block is not an unknown
+    key" — and the assertion they reached for was "still loads". That is the
+    wrong half of the statement. `_rule_matches` returns False for a rule with
+    no matchers and no conditions, so both of these ARE the accepted-and-inert
+    shape A-11 exists to eliminate; the guards were pinning the bug in place.
 
-def test_empty_match_and_empty_conditions_still_load():
-    """(f) control: empty blocks are not 'unknown keys'."""
-    assert _sensor().set_policy({
-        "version": "1", "defaults": {"effect": "allow"},
-        "rules": [{"id": "empty", "effect": "block", "match": {}, "conditions": {}}],
-    }) is True
+    What the scope guard actually needed to say is preserved below: an empty
+    block must not be reported as an UNKNOWN KEY. It is rejected for being
+    unable to fire, which is a different error with a different message.
+    """
+    with caplog.at_level(logging.ERROR, logger="xaidr.authz"):
+        accepted = _sensor().set_policy({
+            "version": "1", "defaults": {"effect": "allow"}, "rules": [rule],
+        })
+    assert accepted is False, f"{label}: rule loaded and can never fire"
+    assert rule["id"] in caplog.text
+    assert "NEVER fire" in caplog.text
+    assert "unknown key" not in caplog.text, (
+        "an empty block is not an unknown key — the A-11 scope guard this test "
+        f"replaced was protecting exactly this: {caplog.text!r}"
+    )
 
 
 def test_unknown_keys_outside_match_are_still_ignored():

--- a/xaidr/authz/policy.py
+++ b/xaidr/authz/policy.py
@@ -78,6 +78,35 @@ _MATCH_FIELDS = {
 # the rule in silence.
 _CONDITION_FIELDS = frozenset({"trust_below", "min_chain_tier_above"})
 
+# The only two keys `defaults:` accepts. Same single-source discipline as above:
+# `_reject_unknown_keys` is pointed at this, so `defaults: {efect: block}` is
+# rejected rather than silently reverting the deployment to allow-by-default.
+_DEFAULTS_FIELDS = frozenset({"effect", "unclassified"})
+
+# A match-field pattern is a string glob. ints/floats are accepted and stringified
+# by `_glob_any` (`impact_tier: [4]`), but bool is NOT: unquoted YAML `yes`/`no`/
+# `on`/`off` parse to True/False and would stringify to "true"/"false", matching
+# nothing real. That is the same silent-inert failure this module rejects.
+_PATTERN_TYPES = (str, int, float)
+
+
+def _typename(value: Any) -> str:
+    """How the operator's mistake reads back to them, in YAML terms."""
+    if value is None:
+        return "an empty value (`null` — a YAML key with nothing after it)"
+    if isinstance(value, bool):
+        return f"a boolean ({str(value).lower()} — unquoted YAML yes/no/on/off)"
+    if isinstance(value, list) and not value:
+        return "an empty list ([])"
+    return f"a {type(value).__name__} ({value!r})"
+
+
+def _as_yaml_list(value: Any) -> str:
+    """The corrected one-liner to put in the error message."""
+    if isinstance(value, _PATTERN_TYPES) and not isinstance(value, bool):
+        return f'["{value}"]'
+    return '["<pattern>", ...]'
+
 
 def _reject_unknown_keys(rule_id: Any, block_name: str, block: dict, known) -> bool:
     """Log and reject the first unrecognized key in a rule's match/conditions.
@@ -88,6 +117,10 @@ def _reject_unknown_keys(rule_id: Any, block_name: str, block: dict, known) -> b
     same failure class as `trust_below`, so it gets the same loud treatment
     rather than being quietly ignored.
 
+    Also used for the top-level `defaults:` block, where the consequence is
+    worse than a dead rule: `defaults: {efect: block}` drops back to the shipped
+    `allow`, turning a deny-by-default deployment into an allow-by-default one.
+
     Returns True when an unknown key was found (caller must reject the policy).
     """
     for key in sorted(block, key=str):
@@ -96,15 +129,124 @@ def _reject_unknown_keys(rule_id: Any, block_name: str, block: dict, known) -> b
         near = difflib.get_close_matches(str(key), sorted(known), n=1, cutoff=0.6)
         did_you_mean = f" Did you mean {near[0]!r}?" if near else ""
         logger.error(
-            "[xaidr] action_policy rule %r has an unknown key %r under '%s:'."
-            "%s A rule with an unrecognized key matches NOTHING — it would load "
-            "cleanly and silently never fire. Policy REJECTED (detection-only). "
+            "[xaidr] action_policy %s has an unknown key %r under '%s:'."
+            "%s An unrecognized key is DROPPED — the block silently loses what "
+            "it was written to do. Policy REJECTED (detection-only). "
             "Valid '%s:' keys: %s.",
-            rule_id, key, block_name, did_you_mean, block_name,
+            "top level" if block_name == "defaults" else f"rule {rule_id!r}",
+            key, block_name, did_you_mean, block_name,
             ", ".join(sorted(known)),
         )
         return True
     return False
+
+
+# ── F5 · type validation ─────────────────────────────────────────────────────
+#
+# A-11 (above) closed the case where a match/conditions KEY is wrong. F5 is the
+# same failure with the key right and the VALUE the wrong shape:
+#
+#     match:
+#       tools: deploy        # not ["deploy"]
+#
+# `_glob_any` returns False for anything that is not a list, so this loads with
+# an INFO line reporting success and then never matches. Every one of the eight
+# match fields behaves this way, as do the `match:`/`conditions:` blocks
+# themselves when they are not mappings, and `defaults:` when it is not one.
+#
+# All of it is rejected at load rather than coerced. The reasoning is in
+# docs/policies.md ("Why a wrong type is rejected, not coerced"); the short form
+# is that coercion can only guess for ONE of these shapes (`scalar -> [scalar]`)
+# and has no defensible guess for the rest — `[]`, a mapping, `null`, a `match:`
+# block that is itself a string — so it would fix the tidiest case and leave the
+# class silently broken, while making the engine's behaviour unpredictable from
+# the file. Rejection costs no enforcement: a rule in this state was already
+# matching nothing, and the reject path lands on the same detection-only
+# fallback the inert rule was already delivering.
+
+
+def _reject_match_value(rule_id: Any, field: str, value: Any) -> bool:
+    """Reject a `match:` value that is not a non-empty list of glob patterns.
+
+    Returns True when the caller must reject the whole policy.
+    """
+    if isinstance(value, list) and value and all(
+        isinstance(p, _PATTERN_TYPES) and not isinstance(p, bool) for p in value
+    ):
+        return False
+
+    common = (
+        "Policy REJECTED (detection-only). '%s:' takes a LIST of glob patterns; "
+        "write it as `%s: %s`."
+    )
+    if value is None:
+        # The one shape that does not merely go inert: `_rule_matches` skips a
+        # None field entirely, so the rule keeps firing WITHOUT this narrower.
+        # `match: {tools: , agents: [a]}` blocks every tool agent `a` calls.
+        logger.error(
+            "[xaidr] action_policy rule %r has 'match: %s:' with %s. A match "
+            "field with no value is SKIPPED at evaluation time, which WIDENS "
+            "the rule — it fires on everything this field was written to "
+            "exclude. " + common,
+            rule_id, field, _typename(value), field, field, _as_yaml_list(value),
+        )
+    elif isinstance(value, list):
+        bad = next((p for p in value
+                    if not isinstance(p, _PATTERN_TYPES) or isinstance(p, bool)), None)
+        detail = (
+            "an empty list — it can never match anything"
+            if not value else
+            f"a non-pattern element ({_typename(bad)}); patterns are strings"
+        )
+        logger.error(
+            "[xaidr] action_policy rule %r has 'match: %s:' set to %s. The rule "
+            "would load cleanly and silently never fire. " + common,
+            rule_id, field, detail, field, field, _as_yaml_list(value),
+        )
+    else:
+        logger.error(
+            "[xaidr] action_policy rule %r has 'match: %s:' set to %s, not a "
+            "list. A non-list match value matches NOTHING — the rule would load "
+            "cleanly and silently never fire, so the operator believes a control "
+            "is active when it is not. " + common,
+            rule_id, field, _typename(value), field, field, _as_yaml_list(value),
+        )
+    return True
+
+
+def _reject_numeric_condition(rule_id: Any, field: str, value: Any, kind: type) -> bool:
+    """Reject a numeric `conditions:` value that cannot be compared.
+
+    `_rule_matches` wraps both numeric comparisons in try/except and returns
+    False on failure, so `min_chain_tier_above: high` is another load-clean,
+    never-fires rule. bool is excluded for the same reason as in match patterns.
+    """
+    ok = isinstance(value, (int, float)) and not isinstance(value, bool)
+    if not ok and isinstance(value, str):
+        try:
+            kind(value)
+            ok = True  # "1" / "0.5" are compared correctly today; keep accepting
+        except (TypeError, ValueError):
+            ok = False
+    if ok:
+        return False
+    consequence = (
+        # None is the widening direction, as with a None match field: the
+        # condition is skipped entirely and the rule fires without it.
+        "The condition is SKIPPED at evaluation time, which WIDENS the rule — "
+        "it fires in exactly the cases this condition was written to exclude."
+        if value is None else
+        "The comparison fails at evaluation time and the rule does NOT match — "
+        "it would load cleanly and silently never fire."
+    )
+    logger.error(
+        "[xaidr] action_policy rule %r has 'conditions: %s:' set to %s, which "
+        "is not a number. %s Policy REJECTED (detection-only). Give '%s:' %s "
+        "value.",
+        rule_id, field, _typename(value), consequence, field,
+        "an int" if kind is int else "a float",
+    )
+    return True
 
 
 @dataclass
@@ -129,9 +271,20 @@ def parse_action_policy(
 
     Unknown keys INSIDE a rule's ``match:`` or ``conditions:`` block are
     REJECTED, not ignored: such a rule loads cleanly and then matches nothing,
-    which is a security control that silently does not run. Unknown fields
-    elsewhere (top level, rule level) remain ignored — those do not disarm
-    anything.
+    which is a security control that silently does not run. Unknown fields at
+    the rule level remain ignored — those do not disarm anything. Unknown keys
+    under ``defaults:`` ARE rejected, because dropping one reverts the
+    deployment to allow-by-default.
+
+    Wrong-TYPED values are rejected on the same grounds (F5): a scalar where a
+    list belongs, a non-mapping ``match:``/``conditions:``/``defaults:`` block,
+    an empty pattern list, or a non-numeric numeric condition all load cleanly
+    and then never fire. The invariant this function enforces is:
+
+        a rule that cannot match anything never loads quietly.
+
+    Either the policy is rejected with an error naming the field and the
+    correction, or every rule in it is capable of firing.
     """
     # S2 · extension-supplied condition names. Resolved ONCE, here, so the two
     # places below that consult it cannot drift apart. Empty for every caller
@@ -142,6 +295,10 @@ def parse_action_policy(
     _condition_fields = _CONDITION_FIELDS | set(_extra)
     try:
         if not isinstance(raw, dict):
+            logger.error(
+                "[xaidr] action_policy must be a mapping, got %s. Policy "
+                "REJECTED (detection-only).", _typename(raw),
+            )
             return None
         if raw.get("version") not in SUPPORTED_VERSIONS:
             logger.warning(f"[xaidr] action_policy version {raw.get('version')!r} unsupported")
@@ -149,13 +306,52 @@ def parse_action_policy(
 
         raw_rules = raw.get("rules", [])
         if not isinstance(raw_rules, list):
+            logger.error(
+                "[xaidr] action_policy 'rules:' must be a list of rules, got "
+                "%s. Policy REJECTED (detection-only).", _typename(raw_rules),
+            )
             return None
 
         rules = []
         for r in raw_rules:
-            if not isinstance(r, dict) or r.get("effect") not in EFFECTS:
-                logger.warning(f"[xaidr] action_policy has a malformed rule: {r!r}")
+            # Same unhashable-value care as in the defaults check below:
+            # `effect: [block]` must be reported as a bad effect, not swallowed
+            # by the catch-all as an unattributed "parse failed".
+            if not isinstance(r, dict):
+                logger.error(
+                    "[xaidr] action_policy 'rules:' contains %s, not a rule "
+                    "mapping. Policy REJECTED (detection-only).", _typename(r),
+                )
                 return None
+            if not isinstance(r.get("effect"), str) or r["effect"] not in EFFECTS:
+                logger.error(
+                    "[xaidr] action_policy rule %r has effect %s, which is not "
+                    "a valid effect. Policy REJECTED (detection-only). Valid "
+                    "effects: %s.",
+                    r.get("id"), _typename(r.get("effect")),
+                    ", ".join(sorted(EFFECTS)),
+                )
+                return None
+            # A non-mapping match:/conditions: block was silently replaced with
+            # {} here, which is how `conditions: "trust_below: 0.5"` (a YAML
+            # string, from one missed indent) slipped past the trust_below
+            # rejection below AND dropped the condition — arming the rule on
+            # traffic the operator had excluded. Both blocks are now validated
+            # before anything reads them.
+            for block_name in ("match", "conditions"):
+                block = r.get(block_name)
+                if block is not None and not isinstance(block, dict):
+                    logger.error(
+                        "[xaidr] action_policy rule %r has a '%s:' block that is "
+                        "%s, not a mapping of field -> value. The block is "
+                        "unreadable, so the rule loads with NO %s at all — it "
+                        "either never fires or fires on everything the dropped "
+                        "%s was written to exclude. Policy REJECTED "
+                        "(detection-only).",
+                        r.get("id"), block_name, _typename(block),
+                        block_name, block_name,
+                    )
+                    return None
             match = r.get("match") if isinstance(r.get("match"), dict) else {}
             conditions = r.get("conditions") if isinstance(r.get("conditions"), dict) else {}
             # trust_below requires a per-agent trust score, which is a platform-
@@ -196,6 +392,45 @@ def parse_action_policy(
                 r.get("id"), "conditions", conditions, _condition_fields
             ):
                 return None
+            # F5 · the keys are right; check the VALUES can actually be matched
+            # against. Ordered after the key checks so a typo'd key keeps its
+            # did-you-mean message instead of being reported as a bad type.
+            for field, value in sorted(match.items(), key=lambda kv: str(kv[0])):
+                if _reject_match_value(r.get("id"), field, value):
+                    return None
+            if _reject_numeric_condition(
+                r.get("id"), "min_chain_tier_above",
+                conditions.get("min_chain_tier_above", 0), int,
+            ):
+                return None
+            # Only reachable when an extension registered `trust_below` (the
+            # guard above rejects it otherwise), but the comparison is still
+            # `float(trust) < float(trust_below)` in this module, so the type is
+            # still this module's to check.
+            if "trust_below" in conditions and _reject_numeric_condition(
+                r.get("id"), "trust_below", conditions["trust_below"], float,
+            ):
+                return None
+            # Extension-registered condition VALUES are deliberately not typed
+            # here: the extension owns their semantics and this module cannot
+            # know what shape `geo_outside:` takes. An evaluator that cannot
+            # answer already fails closed in `_rule_matches`.
+
+            # (d) THE PROPERTY. Everything above rejects a specific mistake;
+            # this catches the general case, including ones nobody enumerated.
+            # `_rule_matches` returns False for a rule with no matchers and no
+            # conditions — at EVALUATION time, invisibly, forever. Same verdict,
+            # moved to load, where an operator is present to read it.
+            if not match and not conditions:
+                logger.error(
+                    "[xaidr] action_policy rule %r has no 'match:' and no "
+                    "'conditions:', so there is nothing for it to match on — it "
+                    "can NEVER fire, whatever its effect says. Policy REJECTED "
+                    "(detection-only). Give the rule at least one match field "
+                    "(%s) or condition.",
+                    r.get("id"), ", ".join(sorted(_MATCH_FIELDS)),
+                )
+                return None
             rules.append({
                 "id": str(r.get("id")) if r.get("id") is not None else None,
                 "effect": r["effect"],
@@ -204,13 +439,59 @@ def parse_action_policy(
                 "message": r.get("message"),
             })
 
-        raw_defaults = raw.get("defaults") if isinstance(raw.get("defaults"), dict) else {}
+        # `defaults:` is the highest-consequence block in the file and had the
+        # quietest failure: a non-mapping was replaced with {} and the policy
+        # loaded with the SHIPPED defaults. `defaults: block` — a plausible
+        # shorthand — parsed as a string, was discarded, and silently turned a
+        # deny-by-default deployment into an allow-by-default one. No rule is
+        # involved, so none of the rule-level guards above could see it.
+        raw_defaults = raw.get("defaults")
+        if raw_defaults is not None and not isinstance(raw_defaults, dict):
+            logger.error(
+                "[xaidr] action_policy 'defaults:' is %s, not a mapping. It "
+                "would be discarded and the policy would fall back to the "
+                "shipped defaults (effect: allow, unclassified: monitor) — a "
+                "deny-by-default policy silently becomes allow-by-default. "
+                "Policy REJECTED (detection-only). Write it as "
+                "`defaults: {effect: ..., unclassified: ...}`.",
+                _typename(raw_defaults),
+            )
+            return None
+        raw_defaults = raw_defaults or {}
+        # Same reasoning for an unknown key: `defaults: {efect: block}` drops
+        # the block effect back to allow with nothing logged.
+        if _reject_unknown_keys(None, "defaults", raw_defaults, _DEFAULTS_FIELDS):
+            return None
         defaults = {
             "effect": raw_defaults.get("effect", "allow"),
             "unclassified": raw_defaults.get("unclassified", "monitor"),
         }
-        if defaults["effect"] not in EFFECTS or defaults["unclassified"] not in EFFECTS:
-            return None
+        for key in ("effect", "unclassified"):
+            # `not in EFFECTS` alone raises TypeError for an unhashable value
+            # (`effect: [block]`), which the catch-all at the bottom turns into
+            # a generic "parse failed" that names neither the key nor the file.
+            if not isinstance(defaults[key], str) or defaults[key] not in EFFECTS:
+                logger.error(
+                    "[xaidr] action_policy 'defaults: %s:' is %s, which is not a "
+                    "valid effect. Policy REJECTED (detection-only). Valid "
+                    "effects: %s.",
+                    key, _typename(defaults[key]), ", ".join(sorted(EFFECTS)),
+                )
+                return None
+
+        # Not a rejection: a `defaults:`-only policy is a legitimate posture
+        # ("block everything, no exceptions"). But a policy with no rules AND
+        # the shipped defaults enforces nothing the operator wrote, and is
+        # indistinguishable from one whose `rules:` was lost to an indent. The
+        # property in (d) is about being LOUD, not about refusing — so this is
+        # loud and still loads.
+        if not rules and defaults == {"effect": "allow", "unclassified": "monitor"}:
+            logger.warning(
+                "[xaidr] action_policy loaded with NO rules and the shipped "
+                "defaults (effect: allow, unclassified: monitor) — it cannot "
+                "change any decision. Check that 'rules:' is present and "
+                "indented as a top-level key.",
+            )
 
         # The registered evaluators ride WITH the parsed policy. `evaluate()`
         # takes (policy, request) and is called from one place; threading a

--- a/xaidr/local_policy.py
+++ b/xaidr/local_policy.py
@@ -45,6 +45,14 @@ Supported match fields: ``tools``, ``agents``, ``impact_class``,
 is NOT supported in this open distribution — it needs a per-agent trust score
 that only the platform tier computes, so a policy using it is REJECTED at load
 (with a clear error) rather than silently never firing.
+
+Every match value is a LIST of glob patterns. ``tools: deploy`` (a scalar) is a
+type error, not a shorthand, and is rejected at load with the correction in the
+message — it would otherwise load cleanly and match nothing, which is the one
+outcome a policy loader must never produce. The same applies to a non-mapping
+``match:``/``conditions:``/``defaults:`` block and to a rule with nothing to
+match on. See ``docs/policies.md`` for the full table and for why these are
+rejected rather than coerced.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
F5. `match: {tools: "deploy"}` — a scalar where a list belongs — parsed without
error, logged `loaded local policy (1 rules)`, and matched nothing. `_glob_any`
returns False for any non-list, so the rule was dead at load and the operator
was told it was active.

Walking the schema found the same shape in 62 of 98 probed cases: all eight
match fields (scalar, int, null, [], mapping, unquoted yes/no, nested list), a
non-mapping `match:`/`conditions:`/`defaults:` block, a non-numeric
`min_chain_tier_above`, an unknown `defaults:` key, and a rule with nothing to
match on. Two directions, not one:

  INERT   the rule never fires
  WIDENED `tools:` with no value is SKIPPED, so `{tools: , agents: [a]}` blocks
          everything agent `a` does; `defaults: block` was discarded and turned
          a deny-by-default deployment into allow-by-default; a stringified
          `conditions:` block bypassed the A-11 trust_below rejection AND
          dropped the condition, arming the rule where the operator excluded it

REJECT, NOT COERCE. Coercion answers one shape of seven and has no defensible
guess for `[]`, a mapping, `null`, or a `match:` block that is itself a string —
it would fix the tidiest case, leave the class broken, and start guessing at
intent in the ARMING direction. The objection that rejection breaks deployments
carrying an inert rule inverts: such a rule was already enforcing nothing, and
the reject path lands on the same detection-only fallback it was already
delivering. Nothing enforced stops being enforced; the operator is now told.
Rejection is whole-policy, following the existing trust_below/unknown-key
contract — half a deny-list is a state nobody authored. Argument in
docs/policies.md.

The property, independent of mechanism: a rule that cannot match anything never
loads quietly. `test_property_no_field_is_accepted_and_inert` asserts exactly
that over every field x every wrong shape, derived from `_MATCH_FIELDS` so a
new field is covered without anyone remembering.

CONTRACT CHANGE: test_rule_with_no_match_block_still_loads and
test_empty_match_and_empty_conditions_still_load asserted `is True` for rules
that cannot fire. They were A-11 scope guards reaching for the wrong half of
"an empty block is not an unknown key" — they pinned the bug. Rewritten to
assert rejection while still guarding that an empty block is not reported as an
unknown key.

Also fixes two unattributed rejections: `effect: [block]` raised TypeError on
`not in EFFECTS` (unhashable) and fell into the catch-all as a generic "parse
failed" naming neither key nor rule.

FAILING-FIRST PROOF (fix stashed, tests kept):
  160 failed, 42 passed

  test_property_no_field_is_accepted_and_inert[tools-scalar-str]
    AssertionError: match.tools = 'v-tools' (scalar-str) was ACCEPTED
    ([{'id': 'the-rule', 'effect': 'block', 'match': {'tools': 'v-tools'}, ...}])
    and then did not fire on input it names (decision='allowed'). This is the F5
    failure mode: the operator believes a control is active and it is inert.

  test_non_mapping_defaults_is_rejected[block-scalar-str]
    AssertionError: defaults: 'block' (scalar-str) loaded as allow-by-default;
    the operator wrote a deny-by-default policy and got the opposite

  test_null_field_does_not_silently_widen_a_rule[agents]
    AssertionError: `tools:` with no value loaded beside agents: the rule now
    fires on every tool, not the ones the operator listed

  Post-fix: 202 passed.

BOTH DIRECTIONS (the gate's scope changed; the old gate is A-11
_reject_unknown_keys). Same inputs, pre-fix:
  F5 input   match: {tools: "deploy"}    A-11 rejects? False   <- discriminating
  A-11 input match: {tool:  ["deploy"]}  A-11 rejects? True

EXTERNAL VERIFICATION (outside pytest, ./xaidr-policy.yaml on disk, real Sensor):
  tools: "deploy_prod"    ERROR ... 'match: tools:' set to a str ('deploy_prod'),
                          not a list ... write it as `tools: ["deploy_prod"]`
                          WARNING ... falling through to detection-only
                          scan_tool_call -> action='allowed'
  tools: ["deploy_prod"]  INFO ... loaded local policy (1 rules)
                          scan_tool_call -> action='blocked'
  scripts/owasp_agentic_probe.py: policy still enforces
                          approval_required 0.60 policy:probe-rule
                          blocked           0.60 policy:probe-rule

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MawJbL3tKerNQzr64Lu6ed
